### PR TITLE
Fix #6102: [RDMD] Changing a string import file doesn't trigger a rebuild

### DIFF
--- a/rdmd.d
+++ b/rdmd.d
@@ -340,11 +340,11 @@ private int rebuild(string root, string fullExe,
         auto rspName = std.path.join(myOwnTmpDir,
                 "rdmd." ~ hash(root, compilerFlags) ~ ".rsp");
 
-		// On Posix, DMD can't handle shell quotes in its response files.
-		version(Posix)
-		{
-			todo = buildTodo(false);
-		}
+        // On Posix, DMD can't handle shell quotes in its response files.
+        version(Posix)
+        {
+            todo = buildTodo(false);
+        }
 
         std.file.write(rspName, todo);
         todo = shellQuote("@"~rspName);


### PR DESCRIPTION
Fix #6102: [RDMD] Changing a string import file doesn't trigger a rebuild
