### PR TITLE
Issue 6452 - RDMD shouldn't put the compiler in the rsp file.

### DIFF
--- a/rdmd.d
+++ b/rdmd.d
@@ -307,7 +307,7 @@ private int rebuild(string root, string fullExe,
         string objDir, in string[string] myModules,
         string[] compilerFlags, bool addStubMain)
 {
-    auto todo = compiler~" "~std.string.join(compilerFlags, " ")
+    auto todo = std.string.join(compilerFlags, " ")
         ~" -of"~shellQuote(fullExe)
         ~" -od"~shellQuote(objDir)
         ~" -I"~shellQuote(dirname(root))
@@ -327,7 +327,7 @@ private int rebuild(string root, string fullExe,
 	// Different shells and OS functions have different limits,
 	// but 1024 seems to be the smallest maximum outside of MS-DOS.
 	enum maxLength = 1024;
- 	if (todo.length + compiler.length >= maxLength)
+    if ((compiler ~ " " ~ todo).length + compiler.length >= maxLength)
 	{
 		auto rspName = std.path.join(myOwnTmpDir,
 				"rdmd." ~ hash(root, compilerFlags) ~ ".rsp");
@@ -335,7 +335,7 @@ private int rebuild(string root, string fullExe,
 		// On Posix, DMD can't handle shell quotes in its response files.
 		version(Posix)
 		{
-			todo = compiler~" "~std.string.join(compilerFlags.dup, " ")
+			todo = std.string.join(compilerFlags.dup, " ")
 				~" -of"~fullExe
 				~" -od"~objDir
 				~" -I"~dirname(root)
@@ -348,6 +348,9 @@ private int rebuild(string root, string fullExe,
 		std.file.write(rspName, todo);
 		todo = compiler ~ " " ~ shellQuote("@"~rspName);
 	}
+
+    else
+        todo = compiler ~ " " ~ todo;
 
     immutable result = run(todo);
     if (result)


### PR DESCRIPTION
This is a fix for issue 6452 - RDMD shouldn't put the compiler in the rsp file: http://d.puremagic.com/issues/show_bug.cgi?id=6452
