### PR TITLE
As kyllingstad said: Make rdmd compile and behave correctly again

### DIFF
--- a/rdmd.d
+++ b/rdmd.d
@@ -310,12 +310,12 @@ private int rebuild(string root, string fullExe,
 {
     string buildTodo(bool shell)
     {
-		// Workaround for BUG3180
-		static string noQuote(string arg)
-		{
-			return arg;
-		}
-		
+        // Workaround for BUG3180
+        static string noQuote(string arg)
+        {
+            return arg;
+        }
+        
         auto quote = shell ? &shellQuote : &noQuote;
         
         auto todo = std.string.join(compilerFlags, " ")
@@ -420,9 +420,9 @@ private string[string] getDependencies(string rootModule, string objDir,
     auto pattern = regex(r"^(import|file|binary|config)\s+([^\(]+)\(?([^\)]*)\)?\s*$");
     foreach (string line; lines(depsReader))
     {
-		auto regexMatch = match(line, pattern);
+        auto regexMatch = match(line, pattern);
         if (regexMatch.empty) continue;
-		auto captures = regexMatch.captures;
+        auto captures = regexMatch.captures;
         switch(captures[1])
         {
         case "import":


### PR DESCRIPTION
This is intended to replace #10. It's like #10, but:
- The workaround for 6524 now works on windows, too.
- "binary" and "config" are kept, but do NOT add their files to the command line or response file (as discussed in #10).
