### PR TITLE
Use objDir (renamed to workDir) for more than just object files.

### DIFF
--- a/rdmd.d
+++ b/rdmd.d
@@ -438,7 +438,7 @@ private string[string] getDependencies(string rootModule, string workDir,
     }
 
     // Check if the old dependency file is fine
-    if (std.file.exists(depsFilename) && !force)
+    if (!force && std.file.exists(depsFilename))
     {
         // See if the deps file is still in good shape
         auto deps = readDepsFile();


### PR DESCRIPTION
Rationale: Previous plastering of hash calls and other "unique path" building all over the code was a manifestation of inconsistency and code duplication. Now, the hash of the relevant parameters is only calculated once, and all compile-specific files are stored in that subdirectory.

This commit also changes the executable file name for generated executables to no longer include the hash. As a result, users no longer see the hash as part of the process name in process lists and pkill/killall tab completion.

Actual object files are now stored in a subdirectory of workDir. The .rsp file is thus now preserved, because 1) it takes up insignificant space 2) it's referenced in --chatty output.

This commit also moves the .deps file into the aforementioned work directory, a suggestion that was raised before.
