### PR TITLE
Replace dur!"minutes"(3) with minutes(3), etc. Maintain a duration!"minutes"(3) for the sake of generic code.

### DIFF
--- a/rdmd.d
+++ b/rdmd.d
@@ -660,7 +660,7 @@ int eval(string todo)
 
     // Clean pathname
     enum lifetimeInHours = 24;
-    auto cutoff = Clock.currTime() - dur!"hours"(lifetimeInHours);
+    auto cutoff = Clock.currTime() - hours(lifetimeInHours);
     foreach (DirEntry d; dirEntries(pathname, SpanMode.shallow))
     {
         if (d.timeLastModified < cutoff)


### PR DESCRIPTION
Replace `dur!"minutes"(3)` with `minutes(3)`, etc. Maintains a `duration!"minutes"(3)` for the sake of generic code. The `dur` is kept as a "to be deprecated" transition path leading up to the preferred alternative of `minutes(3)` for the majority of code, and duration for the rare cases genericness is needed.

These changes provide decreased verbosity without the need for the contrived and controversial `dur` abbreviation, and also without removing the ability to be generic.

I would STRONGLY assert that this is NOT a case of "pointless aliasing" in the std lib: The idea here is that `minutes()/hours()/etc.` ARE the new replacement for `dur`. The `duration` is ADDED functionality on top of `minutes()/hours()/etc.` So why not just use `dur/duration` instead of `minutes()/hours()/etc.`? Because in the vast majority of use-cases, `dur/duration` are needlessly verbose to a degree that's unreasonable for simply referring to X units of Y time.

This is based on discussion, which had overall strong support for the change, in these NG subthreads:

http://forum.dlang.org/post/jj6gjm$2m6a$1@digitalmars.com
http://forum.dlang.org/post/mailman.115.1331078432.4860.digitalmars-d@puremagic.com
http://forum.dlang.org/post/jj6hnv$2o9s$1@digitalmars.com
