### PR TITLE
rdmd: Fix: --force doesn't work with --eval

### DIFF
--- a/rdmd.d
+++ b/rdmd.d
@@ -650,7 +650,7 @@ int eval(string todo)
     auto binName = progname ~ binExt;
 
     bool compileFailure = false;
-    if (!exists(binName) || force)
+    if (force || !exists(binName))
     {
         // Compile it
         std.file.write(progname~".d", todo);


### PR DESCRIPTION
When using --eval, the --force option doesn't actually force a rebuild. This fixes that.
