### PR TITLE
posix.mak to build rdmd ddemangle under posix systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
 *.o
-catdoc
-dman
-rdmd
+*.tag
+/catdoc
+/dman
+/rdmd
+/ddemangle
+/dget
+/tolf
+/findtags
+/detab
 

--- a/posix.mak
+++ b/posix.mak
@@ -1,0 +1,50 @@
+DMD ?= dmd
+PREFIX ?= /usr/local/bin
+
+WITH_DOC ?= no
+DOC ?= ../d-programming-language.org/web
+
+MODEL = 32
+ifneq (,$(MODEL))
+    MODEL_FLAG ?= -m$(MODEL)
+endif
+
+TOOLS = \
+    rdmd \
+    ddemangle \
+    dget \
+    catdoc \
+    detab \
+    tolf
+
+DOC_TOOLS = \
+    findtags \
+    dman
+
+TAGS = \
+    expression.tag \
+    statement.tag
+
+all: $(TOOLS)
+
+$(TOOLS) $(DOC_TOOLS): %: %.d
+	$(DMD) $(MODEL_FLAG) $(DFLAGS) $(<)
+
+$(TAGS): %.tag: $(DOC)/%.html findtags
+	./findtags $(filter %.html,$(^)) > $(@)
+
+dman: $(TAGS)
+dman: DFLAGS += -J.
+
+install: $(TOOLS)
+	install -d $(DESTDIR)$(PREFIX)
+	install -t $(DESTDIR)$(PREFIX) $(^)
+
+clean:
+	rm -f $(TOOLS) $(DOC_TOOLS) $(TAGS) *.o
+
+ifeq ($(WITH_DOC),yes)
+all install: $(DOC_TOOLS)
+endif
+
+.PHONY: all install clean


### PR DESCRIPTION
supports install with `DESTDIR` (very useful under source-based linux distributions)

_Update_:
Requires applying [pull request from @alexrp](https://github.com/D-Programming-Language/tools/pull/33)
Will build `dman` only if it is specified as target or `make -f posix.mak WITH_DOC=yes` (for `install` works too)
