### PR TITLE
Added shebang to catdoc.d

### DIFF
--- a/catdoc.d
+++ b/catdoc.d
@@ -1,3 +1,4 @@
+#!/usr/bin/env rdmd
 module catdoc;
 
 import std.file;


### PR DESCRIPTION
That's about it. It's a bummer some systems use /bin/env and some others use /usr/bin/env, but adding one is better than having neither.
