### PR TITLE
Added license statements where those were missing

### DIFF
--- a/catdoc.d
+++ b/catdoc.d
@@ -1,4 +1,10 @@
 #!/usr/bin/env rdmd
+
+/* Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+
 module catdoc;
 
 import std.file;

--- a/detab.d
+++ b/detab.d
@@ -1,3 +1,7 @@
+/* Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
 
 /* Replace tabs with spaces, and remove trailing whitespace from lines.
  */

--- a/dman.d
+++ b/dman.d
@@ -1,3 +1,7 @@
+/* Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
 
 import std.stdio;
 import std.getopt;

--- a/findtags.d
+++ b/findtags.d
@@ -1,3 +1,7 @@
+/* Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
 
 import std.stdio;
 import std.file;

--- a/rdmd.d
+++ b/rdmd.d
@@ -1,3 +1,16 @@
+/*
+ *  Copyright (C) 2008 by Andrei Alexandrescu
+ *  Written by Andrei Alexandrescu, www.erdani.org
+ *  Based on an idea by Georg Wrede
+ *  Featuring improvements suggested by Christopher Wright
+ *  Windows port using bug fixes and suggestions by Adam Ruppe
+ *
+ *
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+ 
 // Written in the D programming language.
 
 import std.algorithm, std.array, std.c.stdlib, std.datetime,
@@ -800,27 +813,3 @@ void yap(size_t line = __LINE__, T...)(auto ref T stuff)
     else stderr.writeln(stuff);
 }
 
-/*
- *  Copyright (C) 2008 by Andrei Alexandrescu
- *  Written by Andrei Alexandrescu, www.erdani.org
- *  Based on an idea by Georg Wrede
- *  Featuring improvements suggested by Christopher Wright
- *  Windows port using bug fixes and suggestions by Adam Ruppe
- *
- *  This software is provided 'as-is', without any express or implied
- *  warranty. In no event will the authors be held liable for any damages
- *  arising from the use of this software.
- *
- *  Permission is granted to anyone to use this software for any purpose,
- *  including commercial applications, and to alter it and redistribute it
- *  freely, subject to the following restrictions:
- *
- *  o  The origin of this software must not be misrepresented; you must not
- *     claim that you wrote the original software. If you use this software
- *     in a product, an acknowledgment in the product documentation would be
- *     appreciated but is not required.
- *  o  Altered source versions must be plainly marked as such, and must not
- *     be misrepresented as being the original software.
- *  o  This notice may not be removed or altered from any source
- *     distribution.
- */

--- a/tolf.d
+++ b/tolf.d
@@ -1,3 +1,7 @@
+/* Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
 
 /* Replace line endings with LF
  */


### PR DESCRIPTION
Related thread : http://forum.dlang.org/thread/esiqbzfiekzjcmsidsxo@forum.dlang.org

All licenses added are Boost license. rdmd license statement moved to header because package maintainers lack attention ;)
