### PR TITLE
rdmd: Consider PATHEXT on Windows when trying to find dmd

### DIFF
--- a/rdmd.d
+++ b/rdmd.d
@@ -781,14 +781,20 @@ int eval(string todo)
 
 string which(string path)
 {
+    yap("which ", path);
     if (path.canFind(dirSeparator) || altDirSeparator != "" && path.canFind(altDirSeparator)) return path;
-    foreach (envPath; environment["PATH"].splitter(pathSeparator))
+    string[] extensions = [""];
+    version(Windows) extensions ~= environment["PATHEXT"].split(pathSeparator);
+    foreach (extension; extensions)
     {
-        string absPath = buildPath(envPath, path);
-        yap("stat ", absPath);
-        DirEntry e;
-        const exists = collectException(e = dirEntry(absPath)) is null;
-        if (exists && e.isFile) return absPath;
+        foreach (envPath; environment["PATH"].splitter(pathSeparator))
+        {
+            string absPath = buildPath(envPath, path ~ extension);
+            yap("stat ", absPath);
+            DirEntry e;
+            const exists = collectException(e = dirEntry(absPath)) is null;
+            if (exists && e.isFile) return absPath;
+        }
     }
     throw new FileException(path, "File not found in PATH");
 }


### PR DESCRIPTION
When DMD is built with VS, `argv[0]` doesn't always contain an extension, which affects `-v` output and confuses `rdmd`.
