### PR TITLE
refactored GIT_HOME to avoid broken build

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -110,7 +110,7 @@ function installAnew() {
     for project in $projects; do
         (
             cd $wd &&
-            git clone --quiet -o upstream git://github.com/D-Programming-Language/$project.git &&
+            git clone --quiet -o upstream $GIT_HOME/$project.git &&
             touch $tempdir/$project
         ) &
     done
@@ -193,8 +193,8 @@ function makeWorld() {
 # Then make website
     (
         cd "$wd/d-programming-language.org" &&
-        $makecmd -f posix.mak clean DMD="$wd/dmd/src/dmd" MODEL=$model &&
-        $makecmd -f posix.mak html -j $parallel DMD="$wd/dmd/src/dmd" MODEL=$model
+        $makecmd -f posix.mak clean DMD="$wd/dmd/src/dmd" MODEL=$model GIT_HOME=$GIT_HOME &&
+        $makecmd -f posix.mak html -j $parallel DMD="$wd/dmd/src/dmd" MODEL=$model GIT_HOME=$GIT_HOME
     )
 }
 


### PR DESCRIPTION
at least on OSX, building from scratch using update.sh is broken because of d-programming-language.org.git.
I refactored GIT_HOME to set it there and give it as argument to d-programming-language.org.git/posix.mak
see related pull request :
https://github.com/D-Programming-Language/d-programming-language.org/pull/311
