### PR TITLE
add chmodzip utility

### DIFF
--- a/chmodzip.d
+++ b/chmodzip.d
@@ -1,0 +1,92 @@
+
+import std.c.stdio;
+import std.c.stdlib;
+import std.stdio;
+import std.file;
+import std.date;
+import std.zip;
+import std.zlib;
+
+int main(string[] args)
+{
+    if (args.length == 1)
+    {
+        writeln("Usage: zip zipfile attr members...");
+        exit(0);
+    }
+
+    if (args.length == 2)
+    {
+        auto zipname = args[1];
+        auto buffer = cast(byte[])std.file.read(zipname);
+        auto zr = new std.zip.ZipArchive(cast(void[])buffer);
+        writefln("comment = '%s'", zr.comment);
+        foreach (ArchiveMember de; zr.directory)
+        {
+            zr.expand(de);
+            writefln("name = %s", de.name);
+            writefln("\tcomment = %s", de.comment);
+            writefln("\tmadeVersion = x%04x", de.madeVersion);
+            writefln("\textractVersion = x%04x", de.extractVersion);
+            writefln("\tflags = x%04x", de.flags);
+            writefln("\tcompressionMethod = %d", de.compressionMethod);
+            writefln("\tcrc32 = x%08x", de.crc32);
+            writefln("\texpandedSize = %s", de.expandedSize);
+            writefln("\tcompressedSize = %s", de.compressedSize);
+            writefln("\teattr = %03o, %03o", de.externalAttributes >> 16, de.externalAttributes & 0xFFFF);
+            writefln("\tiattr = %03o", de.internalAttributes);
+            writefln("\tdate = %s", std.date.toString(std.date.toDtime(de.time)));
+        }
+        return 0;
+    }
+
+    auto zipname = args[1];
+    auto attr = args[2];
+    auto members = args[3 .. $];
+
+    uint newattr = 0;
+    foreach (c; attr)
+    {
+        if (c < '0' || c > '7' || attr.length > 4)
+            throw new ZipException("attr must be 1..4 octal digits, not " ~ attr);
+        newattr = (newattr << 3) | (c - '0');
+    }
+
+    auto buffer = cast(byte[])std.file.read(zipname);
+    auto zr = new std.zip.ZipArchive(cast(void[])buffer);
+
+    foreach (member; members)
+    {
+        foreach (ArchiveMember de; zr.directory)
+        {
+            if (de.name == member)
+                goto L1;
+        }
+        throw new ZipException(member ~ " not in zipfile " ~ zipname);
+      L1:
+        ;
+    }
+
+    bool changes;
+    foreach (ArchiveMember de; zr.directory)
+    {
+        zr.expand(de);
+
+        foreach (member; members)
+        {
+            if (de.name == member && ((de.externalAttributes >> 16) & 07777) != newattr)
+            {   changes = true;
+                de.madeVersion = 0x317; // necessary or linux unzip will ignore attributes
+                de.externalAttributes = (de.externalAttributes & ~(07777 << 16)) | (newattr << 16);
+                break;
+            }
+        }
+    }
+
+    if (changes)
+    {   void[] data2 = zr.build();
+        std.file.write(zipname, cast(byte[])data2);
+    }
+    return 0;
+}
+


### PR DESCRIPTION
I've been using this to set execute attribute bits when zipping release packages on windows, because the windows zip32 utility doesn't. Usage is like:

dmd2.zip:
        del dmd2.zip
        zip32 -r dmd2 \dmd2*
        chmodzip dmd2.zip 0755 \
        dmd2/freebsd/bin32/rdmd \
        dmd2/freebsd/bin32/dmd \
        dmd2/freebsd/bin32/obj2asm \
        dmd2/freebsd/bin32/dumpobj \
        dmd2/freebsd/bin32/dman \
        dmd2/freebsd/bin32/shell \
        dmd2/freebsd/bin32/ddemangle \
        dmd2/linux/bin32/rdmd \
        dmd2/linux/bin32/dmd \
        dmd2/linux/bin32/obj2asm \
        dmd2/linux/bin32/dumpobj \
        dmd2/linux/bin32/dman \
        dmd2/linux/bin32/ddemangle \
        dmd2/linux/bin64/rdmd \
        dmd2/linux/bin64/dmd \
        dmd2/linux/bin64/obj2asm \
        dmd2/linux/bin64/dumpobj \
        dmd2/linux/bin64/dman \
        dmd2/linux/bin64/ddemangle \
        dmd2/osx/bin/dumpobj \
        dmd2/osx/bin/obj2asm \
        dmd2/osx/bin/shell \
        dmd2/osx/bin/dmd \
        dmd2/osx/bin/rdmd \
        dmd2/osx/bin/dman \
        dmd2/osx/bin/ddemangle
