### PR TITLE
Check for existence of  'objs' directory and create one if it doesn't exist.

### DIFF
--- a/rdmd.d
+++ b/rdmd.d
@@ -192,12 +192,9 @@ int main(string[] args)
         mkdirRecurse(workDir);
     }
 
-    DirEntry objDirEntry;
-    const objDirExists =
-    	collectException(objDirEntry = dirEntry(objDir)) is null;
-    if (objDirExists)
+    if (exists(objDir))
     {
-        enforce(dryRun || objDirEntry.isDir,
+        enforce(dryRun || isDir(objDir),
                 "Entry `"~objDir~"' exists but is not a directory.");
     }
     else


### PR DESCRIPTION
Discovered that when using with latest ldc2 compiler rdmd did not check for existence of directory for object files. This patch check for such a directory and creates one if it doesn't exist.
