### PR TITLE
Fix race condition while removing object directory

### DIFF
--- a/rdmd.d
+++ b/rdmd.d
@@ -426,7 +426,10 @@ private int rebuild(string root, string fullExe,
         if (objDir.exists && objDir.startsWith(workDir))
         {
             yap("rmdirRecurse ", objDir);
-            rmdirRecurse(objDir);
+            // We swallow the exception because of a potential race: two
+            // concurrently-running scripts may attempt to remove this
+            // directory. One will fail.
+            collectException(rmdirRecurse(objDir));
         }
     }
     return 0;


### PR DESCRIPTION
Found this while running the same script several times concurrently.
