### PR TITLE
Adjust paths so that API docs can be served properly using "serve-html"

### DIFF
--- a/dpl-docs/views/ddox.layout.dt
+++ b/dpl-docs/views/ddox.layout.dt
@@ -25,7 +25,8 @@ block body
 
 	section
 		h2 Comments
-		include inc.disqus
+		- if (req is null)
+			include inc.disqus
 
 block copyright
 	block ddox.copyright

--- a/dpl-docs/views/layout.dt
+++ b/dpl-docs/views/layout.dt
@@ -4,31 +4,32 @@ html(lang='en-US')
     | Copyright (c) 1999-2012 by Digital Mars
     | All Rights Reserved Written by Walter Bright
     | http://www.digitalmars.com
+  - string root_dir = info.linkTo(null) ~ (req is null ? "../" : "");
       
   head
     meta(http-equiv='content-type', content='text/html; charset=utf-8')
     block title
     title #{title} - D Programming Language - Digital Mars
 
-    link(rel="stylesheet", type="text/css", href="#{info.linkTo(null)}../css/ddox.css")
-    link(rel="stylesheet", href="#{info.linkTo(null)}../prettify/prettify.css", type="text/css")
+    link(rel="stylesheet", type="text/css", href="#{root_dir}css/ddox.css")
+    link(rel="stylesheet", href="#{root_dir}prettify/prettify.css", type="text/css")
 
     script(src='https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js', type='text/javascript')
-    script(src='#{info.linkTo(null)}../js/codemirror.js')
-    script(src='#{info.linkTo(null)}../js/d.js')
-    script(src='#{info.linkTo(null)}../js/run.js', type='text/javascript')
-    link(rel='stylesheet', href='#{info.linkTo(null)}../css/codemirror.css')
-    link(rel='stylesheet', type='text/css', href='#{info.linkTo(null)}../css/style.css')
-    script(src='#{info.linkTo(null)}../js/hyphenate.js', type='text/javascript')
+    script(src='#{root_dir}js/codemirror.js')
+    script(src='#{root_dir}js/d.js')
+    script(src='#{root_dir}js/run.js', type='text/javascript')
+    link(rel='stylesheet', href='#{root_dir}css/codemirror.css')
+    link(rel='stylesheet', type='text/css', href='#{root_dir}css/style.css')
+    script(src='#{root_dir}js/hyphenate-selectively.js', type='text/javascript')
 
-    script(type="text/javascript", src="#{info.linkTo(null)}../prettify/prettify.js")
-    script(type="text/javascript", src="#{info.linkTo(null)}../js/ddox.js")
+    script(type="text/javascript", src="#{root_dir}prettify/prettify.js")
+    script(type="text/javascript", src="#{root_dir}js/ddox.js")
 
   body.hyphenate
     #top
       #search-box
         form(method='get', action='http://google.com/search')
-          |<img src="#{info.linkTo(null)}../images/search-left.gif" width="11" height="22" alt=""><input id="q" name="q"><input id="search-submit" type="image" src="#{info.linkTo(null)}../images/search-button.gif">
+          |<img src="#{root_dir}images/search-left.gif" width="11" height="22" alt=""><input id="q" name="q"><input id="search-submit" type="image" src="#{root_dir}images/search-button.gif">
           input#domains(type='hidden', name='domains', value='dlang.org')
           input#sourceid(type='hidden', name='sourceid', value='google-search')
           #search-dropdown
@@ -38,7 +39,7 @@ html(lang='en-US')
               option(value='www.digitalmars.com/d/archives') Newsgroup Archives
       #header
         a(href='/')
-          img#logo(width='125', height='95', border='0', alt='D Logo', src='#{info.linkTo(null)}../images/dlogo.png')
+          img#logo(width='125', height='95', border='0', alt='D Logo', src='#{root_dir}images/dlogo.png')
         a#d-language(href='/') D Programming Language 
 
     #navigation
@@ -53,15 +54,15 @@ html(lang='en-US')
         #toctop
           ul
             li
-              a(href='#{info.linkTo(null)}../index.html', title='D Programming Language') D
+              a(href='#{root_dir}index.html', title='D Programming Language') D
             li
-              a(href='#{info.linkTo(null)}../spec.html', title='D Language Specification') Language
+              a(href='#{root_dir}spec.html', title='D Language Specification') Language
             li
-              a(href='#{info.linkTo(null)}../phobos/index.html', title='D Runtime Library') Phobos
+              a(href='#{root_dir}phobos/index.html', title='D Runtime Library') Phobos
             li
-              a(href='#{info.linkTo(null)}../phobos-prerelease/index.html', title='D Runtime Library (prerelease)') Phobos (prerelease)
+              a(href='#{root_dir}phobos-prerelease/index.html', title='D Runtime Library (prerelease)') Phobos (prerelease)
             li
-              a(href='#{info.linkTo(null)}../comparison.html', title='Language Comparisons') Comparisons
+              a(href='#{root_dir}comparison.html', title='Language Comparisons') Comparisons
       .navblock
         block navigation
     


### PR DESCRIPTION
This allows testing building and testing the documentation with much quicker turnaround time than with generating actual .html files (around 4k).
