### PR TITLE
Separate "generated" dir, fixing dustmite build on OSX

### DIFF
--- a/win32.mak
+++ b/win32.mak
@@ -32,7 +32,14 @@ SCP=$(CP)
 
 DFLAGS=-O -release
 
-TARGETS=dman.exe findtags.exe rdmd.exe changed.exe dustmite.exe
+ROOT_OF_THEM_ALL = generated
+ROOT = $(ROOT_OF_THEM_ALL)\windows\32
+
+TARGETS=	$(ROOT)\dman.exe \
+	$(ROOT)\findtags.exe \
+	$(ROOT)\rdmd.exe \
+	$(ROOT)\dustmite.exe
+	#$(ROOT)\changed.exe \
 
 MAKEFILES=win32.mak posix.mak
 
@@ -57,70 +64,70 @@ TAGS=	expression.tag \
 
 targets : $(TARGETS)
 
-expression.tag : findtags.exe $(DOC)\expression.html
+expression.tag : $(ROOT)\findtags.exe $(DOC)\expression.html
 	+findtags $(DOC)\expression.html >expression.tag
 
 
-statement.tag : findtags.exe $(DOC)\statement.html
+statement.tag : $(ROOT)\findtags.exe $(DOC)\statement.html
 	+findtags $(DOC)\statement.html >statement.tag
 
-std_algorithm.tag : findtags.exe $(PHOBOSDOC)\std_algorithm.html
+std_algorithm.tag : $(ROOT)\findtags.exe $(PHOBOSDOC)\std_algorithm.html
 	+findtags $(PHOBOSDOC)\std_algorithm.html >std_algorithm.tag
 
-std_array.tag : findtags.exe $(PHOBOSDOC)\std_array.html
+std_array.tag : $(ROOT)\findtags.exe $(PHOBOSDOC)\std_array.html
 	+findtags $(PHOBOSDOC)\std_array.html >std_array.tag
 
-std_file.tag : findtags.exe $(PHOBOSDOC)\std_file.html
+std_file.tag : $(ROOT)\findtags.exe $(PHOBOSDOC)\std_file.html
 	+findtags $(PHOBOSDOC)\std_file.html >std_file.tag
 
-std_format.tag : findtags.exe $(PHOBOSDOC)\std_format.html
+std_format.tag : $(ROOT)\findtags.exe $(PHOBOSDOC)\std_format.html
 	+findtags $(PHOBOSDOC)\std_format.html >std_format.tag
 
-std_math.tag : findtags.exe $(PHOBOSDOC)\std_math.html
+std_math.tag : $(ROOT)\findtags.exe $(PHOBOSDOC)\std_math.html
 	+findtags $(PHOBOSDOC)\std_math.html >std_math.tag
 
-std_parallelism.tag : findtags.exe $(PHOBOSDOC)\std_parallelism.html
+std_parallelism.tag : $(ROOT)\findtags.exe $(PHOBOSDOC)\std_parallelism.html
 	+findtags $(PHOBOSDOC)\std_parallelism.html >std_parallelism.tag
 
-std_path.tag : findtags.exe $(PHOBOSDOC)\std_path.html
+std_path.tag : $(ROOT)\findtags.exe $(PHOBOSDOC)\std_path.html
 	+findtags $(PHOBOSDOC)\std_path.html >std_path.tag
 
-std_random.tag : findtags.exe $(PHOBOSDOC)\std_random.html
+std_random.tag : $(ROOT)\findtags.exe $(PHOBOSDOC)\std_random.html
 	+findtags $(PHOBOSDOC)\std_random.html >std_random.tag
 
-std_range.tag : findtags.exe $(PHOBOSDOC)\std_range.html
+std_range.tag : $(ROOT)\findtags.exe $(PHOBOSDOC)\std_range.html
 	+findtags $(PHOBOSDOC)\std_range.html >std_range.tag
 
-std_regex.tag : findtags.exe $(PHOBOSDOC)\std_regex.html
+std_regex.tag : $(ROOT)\findtags.exe $(PHOBOSDOC)\std_regex.html
 	+findtags $(PHOBOSDOC)\std_regex.html >std_regex.tag
 
-std_stdio.tag : findtags.exe $(PHOBOSDOC)\std_stdio.html
+std_stdio.tag : $(ROOT)\findtags.exe $(PHOBOSDOC)\std_stdio.html
 	+findtags $(PHOBOSDOC)\std_stdio.html >std_stdio.tag
 
-std_string.tag : findtags.exe $(PHOBOSDOC)\std_string.html
+std_string.tag : $(ROOT)\findtags.exe $(PHOBOSDOC)\std_string.html
 	+findtags $(PHOBOSDOC)\std_string.html >std_string.tag
 
-std_traits.tag : findtags.exe $(PHOBOSDOC)\std_traits.html
+std_traits.tag : $(ROOT)\findtags.exe $(PHOBOSDOC)\std_traits.html
 	+findtags $(PHOBOSDOC)\std_traits.html >std_traits.tag
 
-std_typetuple.tag : findtags.exe $(PHOBOSDOC)\std_typetuple.html
+std_typetuple.tag : $(ROOT)\findtags.exe $(PHOBOSDOC)\std_typetuple.html
 	+findtags $(PHOBOSDOC)\std_typetuple.html >std_typetuple.tag
 
 
-findtags.exe : findtags.d
-	$(DMD) findtags.d
+$(ROOT)\findtags.exe : findtags.d
+	$(DMD) -of$@ findtags.d
 
-dman.exe : dman.d $(TAGS)
-	$(DMD) $(DFLAGS) dman.d -J.
+$(ROOT)\dman.exe : dman.d $(TAGS)
+	$(DMD) $(DFLAGS) -of$@ dman.d -J.
 
-rdmd.exe : rdmd.d
-	$(DMD) $(DFLAGS) rdmd.d advapi32.lib
+$(ROOT)\rdmd.exe : rdmd.d
+	$(DMD) $(DFLAGS) -of$@ rdmd.d advapi32.lib
 
-dustmite.exe : DustMite/dustmite.d DustMite/dsplit.d
-	$(DMD) $(DFLAGS) DustMite/dustmite.d DustMite/dsplit.d -of$@
+$(ROOT)\dustmite.exe : DustMite/dustmite.d DustMite/dsplit.d
+	$(DMD) $(DFLAGS) -of$@ DustMite/dustmite.d DustMite/dsplit.d
 
-changed.exe : changed.d
-	$(DMD) $(DFLAGS) changed.d
+$(ROOT)\changed.exe : changed.d
+	$(DMD) $(DFLAGS) -of$@ changed.d
 
 clean :
 	del $(TARGETS) $(TAGS)


### PR DESCRIPTION
Adjusted the makefiles to put generated files into their own separate "generated" directory, much like phobos's posix makefile.

Aside from cleanliness, this is needed to avoid an OSX build problem with dustmite: OSX is case-insensitive so the "dustmite" build target conflicted with the "DustMite" directory.
