### PR TITLE
Re-allow simple names for individual tool targets

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -78,6 +78,17 @@ PHOBOS_TAGS:= \
 
 all: $(TOOLS) $(CURL_TOOLS) $(ROOT)/dustmite
 
+rdmd:      $(ROOT)/rdmd
+ddemangle: $(ROOT)/ddemangle
+catdoc:    $(ROOT)/catdoc
+detab:     $(ROOT)/detab
+tolf:      $(ROOT)/tolf
+dget:      $(ROOT)/dget
+changed:   $(ROOT)/changed
+findtags:  $(ROOT)/findtags
+dman:      $(ROOT)/dman
+dustmite:  $(ROOT)/dustmite
+
 $(ROOT)/dustmite: DustMite/dustmite.d DustMite/dsplit.d
 	$(DMD) $(MODEL_FLAG) DustMite/dustmite.d DustMite/dsplit.d -of$(@)
 

--- a/win32.mak
+++ b/win32.mak
@@ -64,6 +64,12 @@ TAGS=	expression.tag \
 
 targets : $(TARGETS)
 
+dman:      $(ROOT)\dman.exe
+findtags:  $(ROOT)\findtags.exe
+rdmd:      $(ROOT)\rdmd.exe
+changed:   $(ROOT)\changed.exe
+dustmite:  $(ROOT)\dustmite.exe
+
 expression.tag : $(ROOT)\findtags.exe $(DOC)\expression.html
 	+findtags $(DOC)\expression.html >expression.tag
 


### PR DESCRIPTION
Putting the generated executables into a subdirectory (in pull #74) meant that building individual targets like `make -f posix rdmd` stopped working and changed to (for example) `make -f posix generated/linux/32/rdmd`. This restores the ability to build individual targets via `make -f posix rdmd`, etc.

(This is a fixed version of #76.)
