### PR TITLE
use ddox release version instead of master

### DIFF
--- a/dpl-docs/package.json
+++ b/dpl-docs/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "dpl-docs",
 	"dependencies": {
-		"ddox": "~master"
+		"ddox": ">=0.9.14"
 	},
 	"versions": ["VibeCustomMain"]
 }


### PR DESCRIPTION
I had to manually update the installed ~master version of ddox to circumvent some build errors with dmd v2.063.2.
In general I think we should avoid dependencies on development versions in official repos.
