### PR TITLE
Change crappy nonstandard name 'upstream' to nice standard name 'origin'

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -108,7 +108,7 @@ function installAnew() {
     for project in $projects; do
         (
             cd $wd &&
-            git clone --quiet -o upstream git://github.com/D-Programming-Language/$project.git &&
+            git clone --quiet git://github.com/D-Programming-Language/$project.git &&
             touch $tempdir/$project
         ) &
     done
@@ -139,8 +139,8 @@ function update() {
         local project=$1
         if ! ( cd "$wd/$project" && \
             git checkout master && \
-            git pull upstream master && \
-            git pull upstream master --tags && \
+            git pull origin master && \
+            git pull origin master --tags && \
             git fetch && \
             git fetch --tags) 2>$tempdir/$project.log
         then


### PR DESCRIPTION
It's all my fault.

Back in the day when we were setting up things at github, someone convinced me everybody uses "upstream" as the mothership repository name. I've gotten zero evidence ever since, but things have remained that way in the scripts.

I don't want to puzzle newcomers by using an unusual naming scheme "just because we do it that way". In the spirit of doing things right and not accumulating cruft I'm submitting this.
