### PR TITLE
rdmd: Add etc to list of ignored packages

### DIFF
--- a/rdmd.d
+++ b/rdmd.d
@@ -39,7 +39,7 @@ else
 
 private bool chatty, buildOnly, dryRun, force, preserveOutputPaths;
 private string exe;
-private string[] exclusions = ["std", "core", "tango"]; // packages that are to be excluded
+private string[] exclusions = ["std", "etc", "core", "tango"]; // packages that are to be excluded
 
 version (DigitalMars)
     private enum defaultCompiler = "dmd";


### PR DESCRIPTION
This fixes "The module 'etc.c.curl' is already defined in (program)".
