### PR TITLE
rdmd: Clean up the temporary executable file if the build fails

### DIFF
--- a/rdmd.d
+++ b/rdmd.d
@@ -456,6 +456,8 @@ private int rebuild(string root, string fullExe,
     if (result)
     {
         // build failed
+        if (exists(fullExeTemp))
+            remove(fullExeTemp);
         return result;
     }
     // clean up the dir containing the object file, just not in dry


### PR DESCRIPTION
OPTLINK may leave behind a broken executable, although the build failed.
Depending on user options, this .tmp file may reside outside the
rdmd work directory, so clean it up if it is created.
