### PR TITLE
Fix #12149: ".exe" not auto-added with -of on windows.

### DIFF
--- a/rdmd.d
+++ b/rdmd.d
@@ -395,6 +395,9 @@ private int rebuild(string root, string fullExe,
         string workDir, string objDir, in string[string] myDeps,
         string[] compilerFlags, bool addStubMain)
 {
+    version (Windows)
+        fullExe = fullExe.defaultExtension(".exe");
+    
     // Delete the old executable before we start building.
     yap("stat ", fullExe);
     if (!dryRun && exists(fullExe))


### PR DESCRIPTION
See:

https://d.puremagic.com/issues/show_bug.cgi?id=12149

http://forum.dlang.org/thread/ldc6qt$22tv$1@digitalmars.com?page=2#post-ldhtqj:2413gv:241:40digitalmars.com
