### PR TITLE
rdmd: Add --dependfile option

### DIFF
--- a/rdmd.1
+++ b/rdmd.1
@@ -66,6 +66,9 @@ Add a stub main program to the mix (e.g. for unittesting)
 .IP --makedepend
 Print dependencies in makefile format and exit
 
+.IP --makedepfile=\fIfile\fR
+Print dependencies in makefile format to file and continue
+
 .IP --man
 Open web browser on manual page
 

--- a/rdmd_test.d
+++ b/rdmd_test.d
@@ -206,6 +206,21 @@ void runTests()
     assert(res.output.canFind("depMod_.d : "));
     assert(res.output.replace(r"\", "/").canFind("dsubpack/submod.d"));
 
+    /* Test --makedepfile. */
+
+    string depModFail = packRoot.buildPath("depModFail_.d");
+    std.file.write(depModFail, "module depMod_; import dsubpack.submod; void main() { assert(0); }");
+
+    string depMak = packRoot.buildPath("depMak_.mak");
+    res = execute([rdmdApp, compilerSwitch, "--force", "--build-only", "-I" ~ packRoot, "--makedepfile=" ~ depMak, depModFail]);
+    scope (exit) std.file.remove(depMak);
+
+    string output = std.file.readText(depMak);
+    // simplistic checks
+    assert(output.canFind("depModFail_.d : "));
+    assert(output.replace(r"\", "/").canFind("dsubpack/submod.d"));
+    assert(res.status == 0, res.output);  // only built, assert(0) not called.
+
     /* Test signal propagation through exit codes */
 
     version (Posix)


### PR DESCRIPTION
The idea behind this option is to provide something similar to GCC's -MF
option, which generate a dependency file at the same time it compiles
the program. This is very useful to keep a Makefile with the
dependencies always updated:

``` make
-include .deps.mak

prog:
    rdmd --build-only --dependfile=.deps.mak prog.d
```

On the first build .deps.mak will be created and afterwards, the only
way the dependencies could change is if prog.d or any of its
dependencies change, in which case a build will be triggered and the new
dependencies file will be generated.
