### PR TITLE
Fix  rdmd --makedep(end|file) (issues 12351 and 12354)

### DIFF
--- a/rdmd.d
+++ b/rdmd.d
@@ -317,17 +317,18 @@ size_t indexOfProgram(string[] args)
 
 void writeDeps(string exe, string root, in string[string] myDeps, File fo)
 {
-    fo.write(exe, " : ", root);
+    fo.writeln(exe, r": \");
+    fo.writeln(" ", root, r" \");
     foreach (mod, _; myDeps)
     {
-        fo.write(' ', mod);
+        fo.writeln(" ", mod, r" \");
     }
     fo.writeln();
-    fo.writeln();
-    fo.writeln(root, " :");
+    fo.writeln(root, ":");
     foreach (mod, _; myDeps)
     {
-        fo.writeln(mod, " :");
+        fo.writeln();
+        fo.writeln(mod, ":");
     }
 }
 

--- a/rdmd_test.d
+++ b/rdmd_test.d
@@ -204,10 +204,10 @@ void runTests()
     res = execute([rdmdApp, compilerSwitch, "-I" ~ packRoot, "--makedepend",
             "-of" ~ depMod[0..$-2], depMod]);
     // simplistic checks
-    assert(res.output.canFind("depMod_ : "));
-    assert(res.output.canFind("depMod_.d"));
-    assert(res.output.replace(r"\", "/").canFind("dsubpack/submod.d"));
-    assert(res.output.replace(r"\", "/").canFind("dsubpack/submod.d :"));
+    assert(res.output.canFind(depMod[0..$-2] ~ ": \\\n"));
+    assert(res.output.canFind("\n " ~ depMod ~ " \\\n"));
+    assert(res.output.canFind("\n " ~ subModSrc ~ " \\\n"));
+    assert(res.output.canFind("\n" ~ subModSrc ~ ":\n"));
 
     /* Test --makedepfile. */
 
@@ -222,10 +222,10 @@ void runTests()
 
     string output = std.file.readText(depMak);
     // simplistic checks
-    assert(output.canFind("depModFail_ : "));
-    assert(output.canFind("depModFail_.d"));
-    assert(output.replace(r"\", "/").canFind("dsubpack/submod.d"));
-    assert(output.replace(r"\", "/").canFind("dsubpack/submod.d :"));
+    assert(output.canFind(depModFail[0..$-2] ~ ": \\\n"));
+    assert(output.canFind("\n " ~ depModFail ~ " \\\n"));
+    assert(output.canFind("\n " ~ subModSrc ~ " \\\n"));
+    assert(output.canFind("\n" ~ subModSrc ~ ":\n"));
     assert(res.status == 0, res.output);  // only built, assert(0) not called.
 
     /* Test signal propagation through exit codes */


### PR DESCRIPTION
This pull request basically makes `rdmd --makedep(end|file)` useful. I don't know if anybody used it before (checking it does work), because I have no idea how it could have worked.

Basically this fixes 2 important issues (use the binary produced as the target instead of the source file, and list all the dependencies as empty targets to avoid make errors if you remove a file). Also the output format is improved to make it both more testeable and human-readable.
