### PR TITLE
fix dget build import error

### DIFF
--- a/dget.d
+++ b/dget.d
@@ -5,12 +5,12 @@
 module dget;
 
 import std.algorithm, std.exception, std.file, std.range, std.net.curl;
+static import std.stdio;
 pragma(lib, "curl");
 
 void usage()
 {
-    import std.stdio;
-    writeln("usage: dget [--clone|-c] [--help|-h] <repo>...");
+    std.stdio.writeln("usage: dget [--clone|-c] [--help|-h] <repo>...");
 }
 
 int main(string[] args)


### PR DESCRIPTION
std.stdio wasn't imported. Somehow this didn't cause an error before, but now it does.

Also, now it's imported globally, I've removed the local import from `usage` and changed it to a fully qualified call.
