### PR TITLE
[trivial] Update to ddox 0.9.20.

### DIFF
--- a/dpl-docs/dub.selections.json
+++ b/dpl-docs/dub.selections.json
@@ -1,7 +1,7 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"ddox": "0.9.19",
+		"ddox": "0.9.20",
 		"vibe-d": "0.7.19",
 		"libevent": "~master",
 		"openssl": "~master",

--- a/dpl-docs/package.json
+++ b/dpl-docs/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "dpl-docs",
 	"dependencies": {
-		"ddox": "~>0.9.19"
+		"ddox": "~>0.9.20"
 	},
 	"versions": ["VibeCustomMain"]
 }


### PR DESCRIPTION
A source file slipped the 0.9.19 version. This is the only change of 0.9.20.
