### PR TITLE
Do not exclude tango package from compilation

### DIFF
--- a/rdmd.d
+++ b/rdmd.d
@@ -39,7 +39,7 @@ else
 
 private bool chatty, buildOnly, dryRun, force, preserveOutputPaths;
 private string exe;
-private string[] exclusions = ["std", "etc", "core", "tango"]; // packages that are to be excluded
+private string[] exclusions = ["std", "etc", "core"]; // packages that are to be excluded
 
 version (DigitalMars)
     private enum defaultCompiler = "dmd";


### PR DESCRIPTION
Considering D2 tango uses druntime this is not helpful. Quite the contrary, that force me to use custom rdmd build to test my D1->D2 in-progress ports (which include necessary parts of tango in-line).

I think it is quite reasonable to ask projects using Tango-D2 to specify exclusion manually in their build scripts.
