### PR TITLE
Fix install directory on Posix systems

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -141,8 +141,8 @@ $(ROOT)/dman: DFLAGS += -J.
 
 install: $(TOOLS) $(CURL_TOOLS)
 	$(eval bin_dir=$(if $(filter $(OS),osx), bin, bin$(MODEL)))
-	mkdir -p $(INSTALL_DIR)/$(bin_dir)
-	cp $^ $(INSTALL_DIR)/$(bin_dir)
+	mkdir -p $(INSTALL_DIR)/$(OS)/$(bin_dir)
+	cp $^ $(INSTALL_DIR)/$(OS)/$(bin_dir)
 
 clean:
 	rm -f $(ROOT)/dustmite $(TOOLS) $(CURL_TOOLS) $(DOC_TOOLS) $(TAGS) *.o $(ROOT)/*.o


### PR DESCRIPTION
Currently, tools are installed into `$(INSTALL_DIR)/bin` but they should be installed into `$(INSTALL_DIR)/bin$(MODEL)` on Posix systems (except Mac OS X).

This pull request makes consistent with the corresponding requests for [#3798 for dmd](https://github.com/D-Programming-Language/dmd/pull/3798), [#908 for druntime](https://github.com/D-Programming-Language/druntime/pull/908), and [#2362 for phobos](https://github.com/D-Programming-Language/phobos/pull/2362).
