### PR TITLE
Replace deprecated std.process.system with std.process.executeShell

### DIFF
--- a/dget.d
+++ b/dget.d
@@ -75,7 +75,7 @@ bool hasRepo(string user, string repo)
 void cloneRepo(string user, string repo)
 {
     import std.process;
-    enforce(!system(fmt("git clone git://github.com/%s/%s", user, repo)));
+    enforce(executeShell(fmt("git clone git://github.com/%s/%s", user, repo)).status == 0);
 }
 
 //::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
To fix a compile failure when building the tools repo with `make -f posix.mak`.
