### PR TITLE
rdmd: Don't recompile the program if only current directory changes

### DIFF
--- a/rdmd.d
+++ b/rdmd.d
@@ -396,8 +396,7 @@ private string getWorkPath(in string root, in string[] compilerFlags)
 
     MD5 context;
     context.start();
-    context.put(getcwd().representation);
-    context.put(root.representation);
+    context.put(root.absolutePath().representation);
     foreach (flag; compilerFlags)
     {
         if (irrelevantSwitches.canFind(flag)) continue;


### PR DESCRIPTION
Use the absolute path to the root .d file instead.

It is certainly possible that the build result will depend on
the current directory. For example, if the root file imports
other modules, these will be sought in the current directory
first. However, this is an unlikely use case, and can be
simulated using e.g. --force or -I%CD%.

On the other hand, having your script be rebuilt every time
it is run from a different directory is an unnecessary waste
of time and disk space.
