### PR TITLE
Fix warnings in dustmite

### DIFF
--- a/DustMite/dustmite.d
+++ b/DustMite/dustmite.d
@@ -1126,8 +1126,8 @@ void applyNoRemoveRegex(string[] noRemoveStr)
 				ends ~= c.hit.ptr + c.hit.length;
 			}
 
-		starts.sort;
-		ends.sort;
+		starts.sort();
+		ends.sort();
 
 		int noRemoveLevel = 0;
 


### PR DESCRIPTION
This request fixes the following warnings:

```
DustMite/dustmite.d(1154): Warning: use std.algorithm.sort instead of .sort property
DustMite/dustmite.d(1155): Warning: use std.algorithm.sort instead of .sort property
```
