### PR TITLE
rdmd: Add --extra-file option

### DIFF
--- a/rdmd.1
+++ b/rdmd.1
@@ -66,6 +66,9 @@ Add a stub main program to the mix (e.g. for unittesting)
 .IP --makedepend
 Print dependencies in makefile format and exit
 
+.IP --makedepfile=\fIfile\fR
+Print dependencies in makefile format to file and continue
+
 .IP --man
 Open web browser on manual page
 

--- a/rdmd_test.d
+++ b/rdmd_test.d
@@ -206,6 +206,21 @@ void runTests()
     assert(res.output.canFind("depMod_.d : "));
     assert(res.output.canFind("dsubpack/submod.d"));
 
+    /* Test --makedepfile. */
+
+    string depModFail = packRoot.buildPath("depModFail_.d");
+    std.file.write(depModFail, "module depMod_; import dsubpack.submod; void main() { assert(0); }");
+
+    string depMak = packRoot.buildPath("depMak_.mak");
+    res = execute([rdmdApp, compilerSwitch, "--force", "--build-only", "-I" ~ packRoot, "--makedepfile=" ~ depMak, depModFail]);
+    scope (exit) std.file.remove(depMak);
+
+    string output = std.file.readText(depMak);
+    // simplistic checks
+    assert(output.canFind("depModFail_.d : "));
+    assert(output.canFind("dsubpack/submod.d"));
+    assert(res.status == 0, res.output);  // only built, assert(0) not called.
+
     /* Test signal propagation through exit codes */
 
     version (Posix)


### PR DESCRIPTION
This option includes an extra source or object in the compilation. It is
particularly useful if you need to add an extra object (compiled by
another language maybe) or an extra source (maybe because a .di was
provided) when compiling the program (multiple --extra-file are
allowed).
