### PR TITLE
rdmd: Add --extra-file option

### DIFF
--- a/man/man1/rdmd.1
+++ b/man/man1/rdmd.1
@@ -57,6 +57,16 @@ Evaluate code as in perl -e (multiple --eval allowed)
 .IP --exclude=\fIpackage\fR
 Exclude a package from the build (multiple --exclude allowed)
 
+.IP --extra-file=\fIfile\fR
+Include an extra source or object in the compilation. Useful
+if you need to add an extra object (compiled by another
+language maybe) or an extra source (when rdmd picked up the
+.B "\&.di"
+file rather than the
+.B "\&.d"
+file) when compiling the program (multiple --extra-file
+allowed).
+
 .IP --loop
 Assume \fI"foreach (line; stdin.byLine()) { ... }"\fR for eval
 

--- a/rdmd.d
+++ b/rdmd.d
@@ -40,6 +40,7 @@ else
 private bool chatty, buildOnly, dryRun, force, preserveOutputPaths;
 private string exe;
 private string[] exclusions = ["std", "etc", "core"]; // packages that are to be excluded
+private string[] extraFiles = [];
 
 version (DigitalMars)
     private enum defaultCompiler = "dmd";
@@ -129,6 +130,7 @@ int main(string[] args)
             "eval", &eval,
             "loop", &loop,
             "exclude", &exclusions,
+            "extra-file", &extraFiles,
             "force", &force,
             "help", { writeln(helpString); bailout = true; },
             "main", &addStubMain,
@@ -665,6 +667,9 @@ private string[string] getDependencies(string rootModule, string workDir,
             default: assert(0);
             }
         }
+        // All dependencies specified through --extra-file
+        foreach (immutable moduleSrc; extraFiles)
+            result[moduleSrc] = d2obj(moduleSrc);
         return result;
     }
 
@@ -795,6 +800,8 @@ addition to compiler options, rdmd recognizes the following options:
                       (implies --chatty)
   --eval=code        evaluate code as in perl -e (multiple --eval allowed)
   --exclude=package  exclude a package from the build (multiple --exclude allowed)
+  --extra-file=file  include an extra source or object in the compilation
+                     (multiple --extra-file allowed)
   --force            force a rebuild even if apparently not necessary
   --help             this message
   --loop             assume \"foreach (line; stdin.byLine()) { ... }\" for eval

--- a/rdmd_test.d
+++ b/rdmd_test.d
@@ -169,6 +169,23 @@ void runTests()
     res = execute([rdmdApp, compilerSwitch, "--force", "--exclude=dsubpack", subModObj, subModUser]);
     assert(res.status == 0, res.output);  // building with the dependency succeeds
 
+    /* Test --extra-file. */
+
+    string extraFileDi = tempDir().buildPath("extraFile_.di");
+    std.file.write(extraFileDi, "module extraFile_; void f();");
+    string extraFileD = tempDir().buildPath("extraFile_.d");
+    std.file.write(extraFileD, "module extraFile_; void f() { return; }");
+    string extraFileMain = tempDir().buildPath("extraFileMain_.d");
+    std.file.write(extraFileMain,
+            "module extraFileMain_; import extraFile_; void main() { f(); }");
+
+    res = execute([rdmdApp, compilerSwitch, "--force", extraFileMain]);
+    assert(res.status == 1, res.output); // undefined reference to f()
+
+    res = execute([rdmdApp, compilerSwitch, "--force",
+            "--extra-file=" ~ extraFileD, extraFileMain]);
+    assert(res.status == 0, res.output); // now OK
+
     /* Test --loop. */
     {
     auto testLines = "foo\nbar\ndoo".split("\n");


### PR DESCRIPTION
This option includes an extra source or object in the compilation. It is
particularly useful if you need to add an extra object (compiled by
another language maybe) or an extra source (maybe because a .di was
provided) when compiling the program (multiple --extra-file are
allowed).
