### PR TITLE
incremental builds with rdmd

### DIFF
--- a/rdmd.d
+++ b/rdmd.d
@@ -643,7 +643,7 @@ private HashSet!DepNode[DepNode] getDependencies(string rootModule,
     immutable depsFilename = buildPath(workDir, "rdmd.deps2");
 
     HashSet!DepNode[DepNode] deps;
-    bool doGenerateDepsFile = true;
+    bool mustRebuildDeps = true;
 
     // Check if the old dependency file is fine
     if (!force)
@@ -658,16 +658,11 @@ private HashSet!DepNode[DepNode] getDependencies(string rootModule,
                 .map!(node => node.file)
                 .filter!(f => f != "")
                 .array;
-            bool mustRebuildDeps = allDeps.anyNewerThan(depsT);
-            if (!mustRebuildDeps)
-            {
-                // Cool, we're in good shape
-                doGenerateDepsFile = false;
-            }
+            mustRebuildDeps = allDeps.anyNewerThan(depsT);
         }
     }
 
-    if (doGenerateDepsFile)
+    if (mustRebuildDeps)
     {
         generateDepsFile(depsFilename, rootModule, compilerFlags);
         if (!dryRun) deps = readDepsFile(depsFilename);

--- a/rdmd.d
+++ b/rdmd.d
@@ -156,6 +156,18 @@ int main(string[] args)
         return 1;
     }
 
+    // Validate extensions of extra files (--extra-file)
+    foreach (immutable f; extraFiles)
+    {
+        if (![".d", ".di", objExt].canFind(f.extension))
+        {
+            stderr.writeln("Bad value for --extra-file: \"" ~ f ~ "\". " ~
+                "Value must be a D source file (extension .d or .di) " ~
+                "or an object file (extension " ~ objExt ~ ").");
+            return 1;
+        }
+    }
+
     if (preserveOutputPaths)
     {
         argsBeforeProgram = argsBeforeProgram[0] ~ ["-op"] ~ argsBeforeProgram[1 .. $];
@@ -202,6 +214,9 @@ int main(string[] args)
     bool lib = compilerFlags.canFind("-lib");
     string outExt = lib ? libExt : binExt;
 
+    // -lib implies --build-only. Can't run a library.
+    if (lib) buildOnly = true;
+
     // --build-only implies the user would like a binary in the program's directory
     if (buildOnly && !exe.ptr)
         exe = exeDirname ~ dirSeparator;
@@ -212,43 +227,31 @@ int main(string[] args)
         exe = buildPath(exe, exeBasename) ~ outExt;
     }
 
-    // Compute the object directory and ensure it exists
     immutable workDir = getWorkPath(root, compilerFlags);
     lockWorkPath(workDir); // will be released by the OS on process exit
-    string objDir = buildPath(workDir, "objs");
+
+    /* Replicating the whole path of the source directory into objDirBase.
+    Setting -od to the deep end of that. Transforming all source paths to
+    relative paths. Using -op. This way, the object files all end up in
+    objDirBase.
+
+    With a shallow -od and without -op there would be object file conflicts.
+    With a shallow -od and with -op the object files could end up all over the
+    file system.
+
+    -oq as described in issue 3541 (fully qualified module name as object
+    filename) would be a candidate to simplify this. However, getting the fully
+    qualified module name of an --extra-file would be an undertaking itself.
+    */
+    string objDirBase = buildPath(workDir, "objs2");
+    string objDir = buildPath(objDirBase, getcwd().relativePath("/"));
+
     yap("mkdirRecurse ", objDir);
     if (!dryRun)
         mkdirRecurse(objDir);
 
-    if (lib)
-    {
-        // When building libraries, DMD does not generate object files.
-        // Instead, it uses the -od parameter as the location for the library file.
-        // Thus, override objDir (which is normally a temporary directory)
-        // to be the target output directory.
-        objDir = exe.dirName;
-    }
+    compilerFlags ~= "-I" ~ dirName(root);
 
-    // Fetch dependencies
-    const myDeps = getDependencies(root, workDir, objDir, compilerFlags);
-
-    // --makedepend mode. Just print dependencies and exit.
-    if (makeDepend)
-    {
-        writeDeps(exe, root, myDeps, stdout);
-        return 0;
-    }
-
-    // --makedepfile mode. Print dependencies to a file and continue.
-    // This is similar to GCC's -MF option, very useful to update the
-    // dependencies file and compile in one go:
-    // -include .deps.mak
-    // prog:
-    //      rdmd --makedepfile=.deps.mak --build-only prog.d
-    if (makeDepFile !is null)
-        writeDeps(exe, root, myDeps, File(makeDepFile, "w"));
-
-    // Compute executable name, check for freshness, rebuild
     /*
       We need to be careful about using -o. Normally the generated
       executable is hidden in the unique directory workDir. But if the
@@ -284,13 +287,78 @@ int main(string[] args)
         lastBuildTime = buildWitness.timeLastModified(SysTime.min);
     }
 
-    // Have at it
-    if (chain(root.only, myDeps.byKey).array.anyNewerThan(lastBuildTime))
+    // Fetch dependencies
+    const HashSet!DepNode[DepNode] myDeps = getDependencies(root, workDir,
+        compilerFlags, addStubMain);
+
+    // --makedepend mode. Just print dependencies and exit.
+    if (makeDepend)
     {
-        immutable result = rebuild(root, exe, workDir, objDir,
-                                   myDeps, compilerFlags, addStubMain);
-        if (result)
-            return result;
+        writeDeps(exe, root, myDeps, stdout);
+        return 0;
+    }
+
+    // --makedepfile mode. Print dependencies to a file and continue.
+    // This is similar to GCC's -MF option, very useful to update the
+    // dependencies file and compile in one go:
+    // -include .deps.mak
+    // prog:
+    //      rdmd --makedepfile=.deps.mak --build-only prog.d
+    if (makeDepFile !is null)
+        writeDeps(exe, root, myDeps, File(makeDepFile, "w"));
+
+    string d2obj(string dfile)
+    {
+        return buildPath(objDir, dfile.relativePath).setExtension(objExt);
+    }
+
+    /*
+    Put together file arguments for the compile and link commands.
+    For source files, decide if to (re-)compile or if to reuse an existing
+    object file.
+    Also pick out the libraries. They need to be passed explicitly in the
+    link command.
+    */
+    const SysTime[string] times = !force ? getTimes(myDeps) :
+        (SysTime[string]).init;
+    HashSet!string toCompile;
+    HashSet!string toReuse;
+    HashSet!string libraries;
+    foreach (node; myDeps.byKey)
+    {
+        final switch (node.type)
+        {
+            case DepNode.Type.source:
+            immutable o = d2obj(node.file);
+            if (force || times[node.file].newerThan(o))
+                toCompile.insert(node.file);
+            else toReuse.insert(o);
+            break;
+
+            case DepNode.Type.object: toReuse.insert(node.file); break;
+            case DepNode.Type.other: break;
+
+            case DepNode.Type.library:
+            if (node.file != exe) libraries.insert(node.name);
+            break;
+        }
+    }
+
+    // compile
+    if (!toCompile[].empty)
+    {
+        immutable int r = compile(toCompile[].map!relativePath.array,
+            compilerFlags, objDir, workDir);
+        if (r) return r;
+    }
+
+    // link
+    if (force || times[exe] > lastBuildTime)
+    {
+        const string[] objects = chain(toCompile[].map!d2obj, toReuse[]).array;
+        const string[] libFlags = libraries[].map!(lib => "-L-l" ~ lib).array;
+        if (int r = link(exe, objects, compilerFlags ~ libFlags, workDir))
+            return r;
 
         // Touch the build witness to track the build time
         if (buildWitness != exe)
@@ -328,40 +396,38 @@ size_t indexOfProgram(string[] args)
     return args.length;
 }
 
-void writeDeps(string exe, string root, in string[string] myDeps, File fo)
+void writeDeps(string exe, string root, in HashSet!DepNode[DepNode] myDeps,
+    File fo)
 {
-    fo.writeln(exe, ": \\");
-    fo.write(" ", root);
-    foreach (mod, _; myDeps)
-    {
-        fo.writeln(" \\");
-        fo.write(" ", mod);
-    }
-    fo.writeln();
-    fo.writeln();
-    fo.writeln(root, ":");
-    foreach (mod, _; myDeps)
-    {
-        fo.writeln('\n', mod, ":");
-    }
+     fo.writeln(exe, ": \\");
+     fo.write(" ", root);
+     foreach (node, _; myDeps)
+     {
+         if(node.file == exe || node.file == root) continue;
+         fo.writeln(" \\");
+         fo.write(" ", node.file);
+     }
+     fo.writeln();
+     fo.writeln();
+     fo.writeln(root, ":");
+     foreach (node, _; myDeps)
+     {
+         if(node.file == exe || node.file == root) continue;
+         fo.writeln('\n', node.file, ":");
+     }
 }
 
-bool inALibrary(string source, string object)
+bool inALibrary(string module_, string file)
 {
-    if (object.endsWith(".di")
-            || source == "object" || source == "gcstats")
+    if (file.endsWith(".di")
+            || module_ == "object" || module_ == "gcstats")
         return true;
 
     foreach(string exclusion; exclusions)
-        if (source.startsWith(exclusion~'.'))
+        if (module_.startsWith(exclusion~'.'))
             return true;
 
     return false;
-
-    // another crude heuristic: if a module's path is absolute, it's
-    // considered to be compiled in a separate library. Otherwise,
-    // it's a source module.
-    //return isabs(mod);
 }
 
 private @property string myOwnTmpDir()
@@ -432,13 +498,18 @@ private void unlockWorkPath()
     }
 }
 
-// Rebuild the executable fullExe starting from modules in myDeps
-// passing the compiler flags compilerFlags. Generates one large
-// object file.
+private int compile(in string[] sources, string[] compilerFlags,
+    in string objDir, in string workDir)
+{
+    // Don't pass -lib to the compiler here.
+    compilerFlags = compilerFlags.filter!(flag => flag != "-lib").array();
 
-private int rebuild(string root, string fullExe,
-        string workDir, string objDir, in string[string] myDeps,
-        string[] compilerFlags, bool addStubMain)
+    return runCompiler(["-c", "-od" ~ objDir, "-op"] ~ compilerFlags ~ sources,
+        workDir);
+}
+
+private int link(string fullExe, in string[] objects, in string[] compilerFlags,
+    in string workDir)
 {
     version (Windows)
         fullExe = fullExe.defaultExtension(".exe");
@@ -466,29 +537,22 @@ private int rebuild(string root, string fullExe,
     }
 
     auto fullExeTemp = fullExe ~ ".tmp";
-
-    string[] buildTodo()
+    immutable result = runCompiler(
+        ["-of" ~ fullExeTemp] ~ objects ~ compilerFlags,
+        workDir);
+    if (result)
     {
-        auto todo = compilerFlags
-            ~ [ "-of"~fullExeTemp ]
-            ~ [ "-od"~objDir ]
-            ~ [ "-I"~dirName(root) ]
-            ~ [ root ];
-        foreach (k, objectFile; myDeps) {
-            if(objectFile !is null)
-                todo ~= [ k ];
-        }
-        // Need to add void main(){}?
-        if (addStubMain)
-        {
-            auto stubMain = buildPath(myOwnTmpDir, "stubmain.d");
-            std.file.write(stubMain, "void main(){}");
-            todo ~= [ stubMain ];
-        }
-        return todo;
+        // build failed
+        if (exists(fullExeTemp))
+            remove(fullExeTemp);
+        return result;
     }
-    auto todo = buildTodo();
+    if (!dryRun) rename(fullExeTemp, fullExe);
+    return result;
+}
 
+private int runCompiler(string[] todo, in string workDir)
+{
     // Different shells and OS functions have different limits,
     // but 1024 seems to be the smallest maximum outside of MS-DOS.
     enum maxLength = 1024;
@@ -504,31 +568,7 @@ private int rebuild(string root, string fullExe,
         todo = [ "@"~rspName ];
     }
 
-    immutable result = run([ compiler ] ~ todo);
-    if (result)
-    {
-        // build failed
-        if (exists(fullExeTemp))
-            remove(fullExeTemp);
-        return result;
-    }
-    // clean up the dir containing the object file, just not in dry
-    // run mode because we haven't created any!
-    if (!dryRun)
-    {
-        yap("stat ", objDir);
-        if (objDir.exists && objDir.startsWith(workDir))
-        {
-            yap("rmdirRecurse ", objDir);
-            // We swallow the exception because of a potential race: two
-            // concurrently-running scripts may attempt to remove this
-            // directory. One will fail.
-            collectException(rmdirRecurse(objDir));
-        }
-        yap("mv ", fullExeTemp, " ", fullExe);
-        rename(fullExeTemp, fullExe);
-    }
-    return 0;
+    return run([ compiler ] ~ todo);
 }
 
 // Run a program optionally writing the command line first
@@ -537,7 +577,7 @@ private int rebuild(string root, string fullExe,
 private int run(string[] args, string output = null, bool replace = false)
 {
     import std.conv;
-    yap(replace ? "exec " : "spawn ", args.text);
+    yap(replace ? "exec " : "spawn ", format("%(%s %)", args));
     if (dryRun) return 0;
 
     if (replace && !output.ptr)
@@ -566,22 +606,45 @@ private int exec(string[] args)
     return run(args, null, true);
 }
 
-// Given module rootModule, returns a mapping of all dependees .d
-// source filenames to their corresponding .o files sitting in
-// directory workDir. The mapping is obtained by running dmd -v against
-// rootModule.
+/*
+Get all dependencies of rootModule.
+Returns a mapping of entitites to other entitites that depend on them.
+The mapping is mainly obtained by running dmd -deps against rootModule.
+It also includes nodes for the build target (exe), the compiler binary,
+the compiler config file, extra files from --extra-file, and any stub main file
+from --main.
 
-private string[string] getDependencies(string rootModule, string workDir,
-        string objDir, string[] compilerFlags)
+Example:
+
+File "root.d":
+----
+import foo;
+pragma(lib, "bar");
+----
+
+File "foo.d":
+----
+enum e = import("baz");
+----
+
+Result of `getDependencies("root.d", ...)`:
+[
+    DepNode.other("root"): [],
+    DepNode.source("root.d"): [root],
+    DepNode.source("foo.d"): [DepNode.source("root.d")],
+    DepNode.other("baz"): [DepNode.source("foo.d")],
+    DepNode.library("bar", ""): [DepNode.source("root.d")],
+    DepNode.other("dmd"): [... all source nodes ...],
+    DepNode.other("dmd.conf"): [... all source nodes ...],
+]
+*/
+private HashSet!DepNode[DepNode] getDependencies(string rootModule,
+        string workDir, string[] compilerFlags, bool addStubMain)
 {
-    immutable depsFilename = buildPath(workDir, "rdmd.deps");
+    immutable depsFilename = buildPath(workDir, "rdmd.deps2");
 
-    string[string] readDepsFile()
+    HashSet!DepNode[DepNode] readDepsFile()
     {
-        string d2obj(string dfile)
-        {
-            return buildPath(objDir, dfile.baseName.chomp(".d") ~ objExt);
-        }
         string findLib(string libName)
         {
             // This can't be 100% precise without knowing exactly where the linker
@@ -611,60 +674,61 @@ private string[string] getDependencies(string rootModule, string workDir,
         auto depsReader = File(depsFilename);
         scope(exit) collectException(depsReader.close()); // don't care for errors
 
-        // Fetch all dependencies and append them to myDeps
-        auto pattern = regex(r"^(import|file|binary|config|library)\s+([^\(]+)\(?([^\)]*)\)?\s*$");
-        string[string] result;
-        foreach (string line; lines(depsReader))
+        HashSet!DepNode[DepNode] result;
+
+        // Fetch all dependencies and put them into result
+        auto pattern = regex(`^deps(Import|File|Lib) ` ~
+            `(?P<importing_module>[^ ]+) \((?P<importing_file>[^)]+)\) ` ~
+            `: (?:[^ ]+ : )?` ~ // private/public
+            `(?P<imported_name>[^ ]+)(?: \((?P<imported_file>[^)]+)\))?$`);
+        foreach (string line; depsReader.byLineCopy)
         {
-            auto regexMatch = match(line, pattern);
+            auto regexMatch = matchFirst(line, pattern);
             if (regexMatch.empty) continue;
-            auto captures = regexMatch.captures;
-            switch(captures[1])
+
+            immutable importingModule = regexMatch["importing_module"].strip();
+            immutable importingFile = regexMatch["importing_file"].strip();
+            immutable importedName = regexMatch["imported_name"].strip();
+            immutable importedFile = regexMatch["imported_file"].strip();
+
+            // Don't care about dependencies of libraries.
+            if (inALibrary(importingModule, importingFile)) continue;
+
+            auto importingNode = DepNode.source(importingFile);
+            result.lookupOrInit(importingNode);
+
+            switch(regexMatch[1])
             {
-            case "import":
-                immutable moduleName = captures[2].strip(), moduleSrc = captures[3].strip();
-                if (inALibrary(moduleName, moduleSrc)) continue;
-                immutable moduleObj = d2obj(moduleSrc);
-                result[moduleSrc] = moduleObj;
-                break;
-
-            case "file":
-                result[captures[3].strip()] = null;
-                break;
-
-            case "binary":
-                result[which(captures[2].strip())] = null;
-                break;
-
-            case "config":
-                auto confFile = captures[2].strip;
-                // The config file is special: if missing, that's fine too. So
-                // add it as a dependency only if it actually exists.
-                yap("stat ", confFile);
-                if (confFile.exists)
+            case "Import":
+                if (!inALibrary(importedName, importedFile))
                 {
-                    result[confFile] = null;
+                    auto node = DepNode.source(importedFile);
+                    result.lookupOrInit(node).insert(importingNode);
                 }
                 break;
 
-            case "library":
-                immutable libName = captures[2].strip();
-                immutable libPath = findLib(libName);
-                if (libPath.ptr)
-                {
-                    yap("library ", libName, " ", libPath);
-                    result[libPath] = null;
-                }
+            case "File":
+                auto node = DepNode.other(importedFile);
+                result.lookupOrInit(node).insert(importingNode);
+                break;
+
+            case "Lib":
+                DepNode node = DepNode.library(importedName,
+                    findLib(importedName));
+                if (node.file.ptr)
+                    yap("library ", node.name, " ", node.file);
+                result.lookupOrInit(node).insert(importingNode);
                 break;
 
             default: assert(0);
             }
         }
-        // All dependencies specified through --extra-file
-        foreach (immutable moduleSrc; extraFiles)
-            result[moduleSrc] = d2obj(moduleSrc);
+
         return result;
     }
+
+    HashSet!DepNode[DepNode] deps;
+    bool generateDepsFile = true;
 
     // Check if the old dependency file is fine
     if (!force)
@@ -674,42 +738,211 @@ private string[string] getDependencies(string rootModule, string workDir,
         if (depsT > SysTime.min)
         {
             // See if the deps file is still in good shape
-            auto deps = readDepsFile();
-            auto allDeps = chain(rootModule.only, deps.byKey).array;
+            deps = readDepsFile();
+            auto allDeps = deps.byKey
+                .map!(node => node.file)
+                .filter!(f => f != "")
+                .array;
             bool mustRebuildDeps = allDeps.anyNewerThan(depsT);
             if (!mustRebuildDeps)
             {
                 // Cool, we're in good shape
-                return deps;
+                generateDepsFile = false;
             }
-            // Fall through to rebuilding the deps file
         }
     }
 
-    immutable rootDir = dirName(rootModule);
-
-    // Collect dependencies
-    auto depsGetter =
-        // "cd "~shellQuote(rootDir)~" && "
-        [ compiler ] ~ compilerFlags ~
-        ["-v", "-o-", rootModule, "-I"~rootDir];
-
-    scope(failure)
+    if (generateDepsFile)
     {
-        // Delete the deps file on failure, we don't want to be fooled
-        // by it next time we try
-        collectException(std.file.remove(depsFilename));
+        // Don't pass -lib to the compiler here.
+        compilerFlags = compilerFlags.filter!(flag => flag != "-lib").array();
+
+        // Collect dependencies
+        auto depsGetter =
+            [ compiler ] ~ compilerFlags ~
+            ["-deps", "-o-", rootModule];
+
+        scope(failure)
+        {
+            // Delete the deps file on failure, we don't want to be fooled
+            // by it next time we try
+            collectException(std.file.remove(depsFilename));
+        }
+
+        immutable depsExitCode = run(depsGetter, depsFilename);
+        if (depsExitCode)
+        {
+            stderr.writefln("Failed: %(%s %)", depsGetter);
+            collectException(std.file.remove(depsFilename));
+            exit(depsExitCode);
+        }
+
+        if (!dryRun) deps = readDepsFile();
     }
 
-    immutable depsExitCode = run(depsGetter, depsFilename);
-    if (depsExitCode)
+    // Add exe as the root of the dependency graph.
+    auto exeNode = DepNode.other(exe);
+    deps[exeNode] = HashSet!DepNode();
+    deps.lookupOrInit(DepNode.source(rootModule)).insert(exeNode);
+        /* Reading the deps file above did make an entry for the root module,
+        but it may have used a different path to the same file.
+        This is why lookupOrInit is here.
+        Ideally, there should be only one entry per file. But one extra
+        entry isn't so bad, I suppose. */
+
+    // All dependencies specified through --extra-file
+    foreach (immutable f; extraFiles)
     {
-        stderr.writefln("Failed: %s", depsGetter);
-        collectException(std.file.remove(depsFilename));
-        exit(depsExitCode);
+        DepNode extraNode;
+        switch (f.extension)
+        {
+            case ".d": case ".di": extraNode = DepNode.source(f); break;
+            case objExt: extraNode = DepNode.object(f); break;
+            default: assert(false);
+        }
+        deps.lookupOrInit(extraNode).insert(exeNode);
     }
 
-    return dryRun ? null : readDepsFile();
+    // Need to add void main(){}?
+    if (addStubMain)
+    {
+        auto stubMain = buildPath(myOwnTmpDir, "stubmain.d");
+        std.file.write(stubMain, "void main(){}");
+        deps.lookupOrInit(DepNode.source(stubMain)).insert(exeNode);
+    }
+
+    // add compiler binary and config file as dependencies to all source files
+
+    void addDepenencyToAllSourceFiles(DepNode dependency)
+    {
+        deps.lookupOrInit(dependency);
+        foreach (dependent; deps.byKey)
+        {
+            if (dependent.type == DepNode.Type.source)
+                deps[dependency].insert(dependent);
+        }
+    }
+
+    // binary
+    immutable binaryNode = DepNode.other(which(compiler));
+    deps.lookupOrInit(binaryNode);
+    addDepenencyToAllSourceFiles(binaryNode);
+
+    // config file
+    {
+        immutable cmd = [compiler, "--help"];
+        auto pipes = pipeProcess(cmd);
+
+        auto pattern = regex(`^Config file: (.*)$`);
+        foreach (line; pipes.stdout.byLineCopy)
+        {
+            auto m = line.matchFirst(pattern);
+            if (m)
+            {
+                immutable confFile = m[1].strip;
+                // The config file is special: if missing, that's fine too. So
+                // add it as a dependency only if it actually exists.
+                if (confFile.exists)
+                {
+                    addDepenencyToAllSourceFiles(DepNode.other(m[1]));
+                }
+                break;
+            }
+        }
+
+        if (int status = wait(pipes.pid))
+        {
+            stderr.writefln("Failed: %(%s %)", cmd);
+            exit(status);
+        }
+    }
+
+    return deps;
+}
+
+struct DepNode
+{
+    enum Type {source, object, other, library}
+    Type type;
+
+    string file; // may be missing with type == library; must be set otherwise
+    string name; // must be set when type == library; must not be set otherwise
+
+    this(Type type, string file, string name)
+    {
+        this.type = type;
+        this.file = file;
+        this.name = name;
+    }
+
+    invariant()
+    {
+        if (type == Type.library) assert(name != "");
+        else
+        {
+            assert(name == "");
+            assert(file != "");
+        }
+    }
+
+    static DepNode source(string file) {return DepNode(Type.source, file, "");}
+    static DepNode object(string file) {return DepNode(Type.object, file, "");}
+    static DepNode other(string file) {return DepNode(Type.other, file, "");}
+    static DepNode library(string name, string file)
+    {
+        return DepNode(Type.library, file, name);
+    }
+}
+
+/* Get the relevant modification times for all files in 'dependencies'.
+The relevant time for a file is the maximum of its own time and the times of
+all files it depends on. */
+SysTime[string] getTimes(const HashSet!DepNode[DepNode] dependencies)
+{
+    SysTime[string] times;
+    /* Update the times of 'node' and all nodes that depend on it to t, if t is
+    greater than the currently stored time. */
+    void updateTimes(DepNode node, SysTime t)
+    {
+        /* No associated file? Then don't add to 'times'. And without a file,
+        this can't depend on anything. Which means this can only be a root call
+        (t = SysTime.min). So there's no point in propagating t upwards.
+        Nothing to do. */
+        if (node.file == "")
+        {
+            assert(t == SysTime.min); // root call
+            return;
+        }
+
+        /* If there's a time stored and it's newer than or equal to t, then
+        there's nothing to do here. */
+        if ((node.file in times) !is null && times[node.file] >= t) return;
+
+        if ((node.file in times) is null)
+            times[node.file] = timeLastModified(node.file, SysTime.min);
+        if (t > times[node.file])
+            times[node.file] = t;
+
+        // Update the times of all dependent nodes, too.
+        if (times[node.file] > SysTime.min)
+        {
+            foreach (dependent; dependencies.get(node, HashSet!DepNode.init)[])
+                updateTimes(dependent, times[node.file]);
+        }
+    }
+
+    /* Sort nodes by modification time, descending. Processing them in this
+    order guarantees that the same path isn't updated more than once. */
+    const DepNode[] nodesByTime = dependencies.byKey.array
+        .sort!((a, b) =>
+            // Not newerThan because that's not antisymmetric as sort requires.
+            timeLastModified(a.file, SysTime.min) >
+            timeLastModified(b.file, SysTime.min)
+        )
+        .release;
+
+    foreach (node; nodesByTime) updateTimes(node, SysTime.min);
+    return times;
 }
 
 // Is any file newer than the given file?
@@ -774,6 +1007,13 @@ private bool newerThan(string source, SysTime target)
         // File not there, consider it newer
         return true;
     }
+}
+
+private bool newerThan(SysTime source, string target)
+{
+    if (force) return true;
+    yap("stat ", target);
+    return source > target.timeLastModified(SysTime.min);
 }
 
 private @property string helpString()
@@ -903,4 +1143,25 @@ void yap(size_t line = __LINE__, T...)(auto ref T stuff)
     if (!chatty) return;
     debug stderr.writeln(line, ": ", stuff);
     else stderr.writeln(stuff);
+}
+
+private struct HashSet(T) // quick implementation abusing an associative array
+{
+    private bool[T] aa;
+    this(T[] values ...) {foreach (v; values) insert(v);}
+    void insert(T thing) {aa[thing] = true;}
+    auto opIndex() {return aa.byKey;}
+    auto opIndex() const {return aa.byKey;}
+    bool contains(T thing) const {return (thing in aa) !is null;}
+}
+
+private V* lookupOrInit(K, V)(ref V[K] aa, K key)
+{
+    V* p = key in aa;
+    if (p is null)
+    {
+        aa[key] = V.init;
+        p = key in aa;
+    }
+    return p;
 }


### PR DESCRIPTION
Inspired by Andrei's call for "scaling up rdmd" ([forum post](http://forum.dlang.org/post/mkshup$2jn0$1@digitalmars.com), [issue 14654](https://issues.dlang.org/show_bug.cgi?id=14654)).

But this doesn't implement Andrei's idea. Instead it does what [Jacob Carlborg](http://forum.dlang.org/post/mkvf7i$27ov$1@digitalmars.com) and [myself](http://forum.dlang.org/post/qpwzoisubakbmuasrnoz@beta.forum.dlang.org) thought might be a better approach: Compile all outdated files, and only those, with one compiler invocation to multiple object files. Seems to work fine.

See commit message for a summary of the process.

I'm planning to add some tests to rdmd_test tomorrow. But code-wise I'm happy with it now; ready to get destroyed.
