### PR TITLE
Issue 15282 - Import osmodel.mak from dmd to detect OS and MODEL

### DIFF
--- a/osmodel.mak
+++ b/osmodel.mak
@@ -1,0 +1,52 @@
+# This Makefile snippet detects the OS and the architecture MODEL
+# Keep this file in sync between druntime, phobos, and dmd repositories!
+
+ifeq (,$(OS))
+  uname_S:=$(shell uname -s)
+  ifeq (Darwin,$(uname_S))
+    OS:=osx
+  endif
+  ifeq (Linux,$(uname_S))
+    OS:=linux
+  endif
+  ifeq (FreeBSD,$(uname_S))
+    OS:=freebsd
+  endif
+  ifeq (OpenBSD,$(uname_S))
+    OS:=openbsd
+  endif
+  ifeq (Solaris,$(uname_S))
+    OS:=solaris
+  endif
+  ifeq (SunOS,$(uname_S))
+    OS:=solaris
+  endif
+  ifeq (,$(OS))
+    $(error Unrecognized or unsupported OS for uname: $(uname_S))
+  endif
+endif
+
+# When running make from XCode it may set environment var OS=MACOS.
+# Adjust it here:
+ifeq (MACOS,$(OS))
+  OS:=osx
+endif
+
+ifeq (,$(MODEL))
+  ifeq ($(OS), solaris)
+    uname_M:=$(shell isainfo -n)
+  else
+    uname_M:=$(shell uname -m)
+  endif
+  ifneq (,$(findstring $(uname_M),x86_64 amd64))
+    MODEL:=64
+  endif
+  ifneq (,$(findstring $(uname_M),i386 i586 i686))
+    MODEL:=32
+  endif
+  ifeq (,$(MODEL))
+    $(error Cannot figure 32/64 model from uname -m: $(uname_M))
+  endif
+endif
+
+MODEL_FLAG:=-m$(MODEL)

--- a/osmodel.mak
+++ b/osmodel.mak
@@ -1,5 +1,5 @@
 # This Makefile snippet detects the OS and the architecture MODEL
-# Keep this file in sync between druntime, phobos, and dmd repositories!
+# Keep this file in sync between druntime, phobos, tools, and dmd repositories!
 
 ifeq (,$(OS))
   uname_S:=$(shell uname -s)

--- a/posix.mak
+++ b/posix.mak
@@ -7,45 +7,7 @@ PHOBOS_PATH = ../phobos
 WITH_DOC = no
 DOC = ../dlang.org
 
-ifeq (,$(OS))
-    uname_S:=$(shell uname -s)
-    ifeq (Darwin,$(uname_S))
-        OS=osx
-    endif
-    ifeq (Linux,$(uname_S))
-        OS=linux
-    endif
-    ifeq (FreeBSD,$(uname_S))
-        OS=freebsd
-    endif
-    ifeq (OpenBSD,$(uname_S))
-        OS=openbsd
-    endif
-    ifeq (Solaris,$(uname_S))
-        OS=solaris
-    endif
-    ifeq (SunOS,$(uname_S))
-        OS=solaris
-    endif
-    ifeq (,$(OS))
-        $(error Unrecognized or unsupported OS for uname: $(uname_S))
-    endif
-endif
-
-ifeq (,$(MODEL))
-    uname_M:=$(shell uname -m)
-    ifeq (x86_64,$(uname_M))
-        MODEL=64
-    else
-        ifeq (i686,$(uname_M))
-            MODEL=32
-        else
-            $(error Cannot figure 32/64 model from uname -m: $(uname_M))
-        endif
-    endif
-endif
-
-MODEL_FLAG=-m$(MODEL)
+include osmodel.mak
 
 ROOT_OF_THEM_ALL = generated
 ROOT = $(ROOT_OF_THEM_ALL)/$(OS)/$(MODEL)


### PR DESCRIPTION
In order to compile the "tools" on a lot of operating systems, I'd like to suggest to use osmodel.mak.

https://issues.dlang.org/show_bug.cgi?id=15282
