### PR TITLE
Fix import deprecation warning.

### DIFF
--- a/ddemangle.d
+++ b/ddemangle.d
@@ -14,7 +14,7 @@ import std.algorithm : equal, map;
 import std.getopt;
 import std.regex;
 import std.stdio;
-import std.c.stdlib;
+import core.stdc.stdlib;
 
 void showhelp(string[] args)
 {


### PR DESCRIPTION
Warning with 2.071.0:
`ddemangle.d(17): Deprecation: module std.c.stdlib is deprecated - Import core.stdc.stdlib or core.sys.posix.stdlib instead`