### PR TITLE
Enable Travis with rdmd testsuite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: d
+d:
+  - dmd
+sudo: false
+addons:
+  apt:
+    packages:
+    - g++-multilib
+    - libcurl3-gnutls:i386
+env:
+  - MODEL=32
+  - MODEL=64
+
+script:
+  - ./travis.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 D tools
 =======
 
+[![Build Status](https://travis-ci.org/dlang/tools.svg?branch=master)](https://travis-ci.org/dlang/tools)
+
 This repository hosts various tools redistributed with DMD or used
 internally during various build tasks.
 

--- a/rdmd.d
+++ b/rdmd.d
@@ -53,6 +53,7 @@ else
 
 private string compiler = defaultCompiler;
 
+version(unittest) {} else
 int main(string[] args)
 {
     //writeln("Invoked with: ", args);

--- a/travis.sh
+++ b/travis.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -uexo pipefail
+
+DIGGER_DIR="../digger"
+DIGGER="../digger/digger"
+
+# set to 64-bit by default
+if [ -z ${MODEL:-} ] ; then
+    MODEL=64
+fi
+
+test_rdmd() {
+    # run rdmd internal tests
+    rdmd -m$MODEL -main -unittest rdmd.d
+
+    # compile rdmd & testsuite
+    dmd -m$MODEL rdmd.d
+    dmd -m$MODEL rdmd_test.d
+
+    # run rdmd testsuite
+    ./rdmd_test
+}
+
+build_digger() {
+    git clone --recursive https://github.com/CyberShadow/Digger "$DIGGER_DIR"
+    dub --root="$DIGGER_DIR" build
+}
+
+install_digger() {
+    $DIGGER build --model=$MODEL "master"
+    export PATH=$PWD/result/bin:$PATH
+}
+
+if ! [ -d "$DIGGER_DIR" ] ; then
+    build_digger
+fi
+
+install_digger
+
+dmd --version
+rdmd --help | head -n 1
+
+test_rdmd


### PR DESCRIPTION
I used digger to automatically get the latest HEAD version.
@CyberShadow would you be so kind to enable Travis? Thanks!

https://travis-ci.org/dlang/tools