### PR TITLE
use ctRegex + avoid array allocation

### DIFF
--- a/rdmd.d
+++ b/rdmd.d
@@ -289,7 +289,7 @@ int main(string[] args)
     }
 
     // Have at it
-    if (chain(root.only, myDeps.byKey).array.anyNewerThan(lastBuildTime))
+    if (chain(root.only, myDeps.byKey).anyNewerThan(lastBuildTime))
     {
         immutable result = rebuild(root, exe, workDir, objDir,
                                    myDeps, compilerFlags, addStubMain);
@@ -617,7 +617,7 @@ private string[string] getDependencies(string rootModule, string workDir,
         scope(exit) collectException(depsReader.close()); // don't care for errors
 
         // Fetch all dependencies and append them to myDeps
-        auto pattern = regex(r"^(import|file|binary|config|library)\s+([^\(]+)\(?([^\)]*)\)?\s*$");
+        auto pattern = ctRegex!(r"^(import|file|binary|config|library)\s+([^\(]+)\(?([^\)]*)\)?\s*$");
         string[string] result;
         foreach (string line; lines(depsReader))
         {


### PR DESCRIPTION
These are two simple gotchas that I found during #195 and are independent to it or any refactoring.
Btw interestingly the compilation increases about 0.1s, but for the optimized build it decreases for nearly 0.2s

Compilation
---------------------

command | compilation time
-------------------|--------------------
|`dmd rdmd-master.d` | 1.21s
|`dmd rdmd.d` | 1.31s
|`dmd -O rdmd-master.d` | 1.96s
|`dmd -O rdmd.d` | 1.77s

```
echo rdmd_master.d rdmd.d "-O rdmd" | tr ' ' '\n' | parallel -j1 "echo {}; python -m timeit -n 5 -r 3 -s 'import os' 'os.system(\"dmd {}\")'"
```

Run time
---------------

With the used at #191 

command | compilation time
-------------------|--------------------
|`rdmd-master` | 607ms
|`rdmd-ct` | 605ms
|`rdmd-master-opt` | 598ms
|`rdmd-ct-opt` | 557ms

For a simple file with only two imports

command | compilation time
-------------------|--------------------
|`rdmd-master` | 135ms
|`rdmd-ct` | 133ms
|`rdmd-master-opt` | 124ms
|`rdmd-ct-opt` | 111ms

For the benchmarks the following command was used :

```
echo rdmd-master rdmd-ct rdmd-master-opt rdmd-ct-opt | tr ' ' '\n' | parallel -j1 "echo {}; python -m timeit -n 10 -r 3 -s 'import os' 'os.system(\"./{} --force -main t1.d > /dev/null 2>&1\")'"
```

edit: `rdmd-master` = commit 1260719a9ce64b012dac5c6287e179353afaaefa