### PR TITLE
Add tag & stats badges to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 D tools
 =======
 
+[![GitHub tag](https://img.shields.io/github/tag/dlang/tools.svg?maxAge=86400)](#)
 [![Build Status](https://travis-ci.org/dlang/tools.svg?branch=master)](https://travis-ci.org/dlang/tools)
+[![Issue Stats](https://img.shields.io/issuestats/p/github/dlang/tools.svg?maxAge=2592000)](http://www.issuestats.com/github/dlang/tools)
 
 This repository hosts various tools redistributed with DMD or used
 internally during various build tasks.


### PR DESCRIPTION
Adds more nice badges to the tools repo.
The tag badge will automatically show the latest git tag and the issue stats is intended as positive motivation for contributors.