### PR TITLE
ddemangle, flush output for each new demangled line

### DIFF
--- a/ddemangle.d
+++ b/ddemangle.d
@@ -109,7 +109,10 @@ void main(string[] args)
     {
         auto f = (args.length==2) ? File(args[1], "r") : stdin;
         foreach (line; f.byLine())
+        {
             writeln(ddemangle(line));
+            stdout.flush;
+        }
     }
     catch(Exception e)
     {


### PR DESCRIPTION
It was not possible to use _ddemangle_ as a service because it didn't flushed each new line. Now an IDE can execute the tool only once and use it when needed. Previously it was impossible and an IDE had to launch the process each time it had something to demangle, which was not optimal.