### PR TITLE
fix issue 16966 - rdmd: AssertError@rdmd.d(489): should have been cre…

### DIFF
--- a/rdmd_test.d
+++ b/rdmd_test.d
@@ -373,6 +373,16 @@ void runTests()
     res = execute([rdmdApp, compilerSwitch, "--tmpdir=" ~ tmpdir, forceSrc, "--build-only"]);
     assert(res.status == 0, res.output);
     assert(res.output.canFind("compile_force_src"));
+
+    /* issue 16966 */
+    immutable voidMainExe = setExtension(voidMain, binExt);
+    res = execute([rdmdApp, compilerSwitch, voidMain]);
+    assert(res.status == 0, res.output);
+    assert(!exists(voidMainExe));
+    res = execute([rdmdApp, compilerSwitch, "--build-only", voidMain]);
+    assert(res.status == 0, res.output);
+    assert(exists(voidMainExe));
+    remove(voidMainExe);
 }
 
 void runConcurrencyTest()


### PR DESCRIPTION
…ated by compileRootAndGetDeps

The bug:

```
rdmd test.d
rdmd --build-only test.d
```

On the first run everything is fine.

On the second run, `compileRootAndGetDeps` looks at rdmd.deps to decide if it needs to compile the root module. rdmd.deps is present from the first build, so it looks like everything is up to date and there's apparently no reason to rebuild the root module. But the specified executable doesn't exist, so some code in `main` correctly decides that a rebuild is needed. The build cannot succeed without the root object, of course.

This fix:

I'm passing `main`'s `lastBuildTime` to `compileRootAndGetDeps` and check there if the root module needs to be compiled even when the dependencies don't need to be obtained.

That complicates `compileRootAndGetDeps` some more. I'm not really happy with my fix here, but I can't seem to come up with something nicer. rdmd could probably use some refactorings.