### PR TITLE
Improve Travis CI setup -> compile all executable

### DIFF
--- a/chmodzip.d
+++ b/chmodzip.d
@@ -26,14 +26,13 @@ int main(string[] args)
             zr.expand(de);
             writefln("name = %s", de.name);
             writefln("\tcomment = %s", de.comment);
-            writefln("\tmadeVersion = x%04x", de.madeVersion);
             writefln("\textractVersion = x%04x", de.extractVersion);
             writefln("\tflags = x%04x", de.flags);
             writefln("\tcompressionMethod = %d", de.compressionMethod);
             writefln("\tcrc32 = x%08x", de.crc32);
             writefln("\texpandedSize = %s", de.expandedSize);
             writefln("\tcompressedSize = %s", de.compressedSize);
-            writefln("\teattr = %03o, %03o", de.externalAttributes >> 16, de.externalAttributes & 0xFFFF);
+            writefln("\teattr = %03o, %03o", de.fileAttributes);
             writefln("\tiattr = %03o", de.internalAttributes);
             //writefln("\tdate = %s", std.date.toString(std.date.toDtime(de.time)));
             writefln("\tdate = %s", SysTime(unixTimeToStdTime((de.time))));
@@ -74,11 +73,10 @@ L1:
 
         foreach (member; members)
         {
-            if (de.name == member && ((de.externalAttributes >> 16) & octal!7777) != newattr)
+            if (de.name == member && (de.fileAttributes & octal!7777) != newattr)
             {
                 changes = true;
-                de._madeVersion = 0x317; // necessary or linux unzip will ignore attributes
-                de.externalAttributes = (de.externalAttributes & ~(octal!7777 << 16)) | (newattr << 16);
+                de.fileAttributes = de.fileAttributes & ~octal!7777 | newattr;
                 break;
             }
         }

--- a/dman.d
+++ b/dman.d
@@ -142,7 +142,7 @@ string CHeader(string topic)
     static string[] dmccmds =
     [
         "assert.h",     "complex.h",   "ctype.h",      "fenv.h",
-        "float.h",      "locale.h",    "math.h",       "setjmp.h,"
+        "float.h",      "locale.h",    "math.h",       "setjmp.h,",
         "signal.h",     "stdarg.h",    "stddef.h",     "stdio.h",
         "stdlib.h",     "string.h",    "time.h",       "gc.h",
         "bios.h",       "cerror.h",    "disp.h",       "dos.h",

--- a/posix.mak
+++ b/posix.mak
@@ -61,13 +61,7 @@ $(ROOT)/dustmite: DustMite/dustmite.d DustMite/splitter.d
 	$(DMD) $(MODEL_FLAG) $(DFLAGS) DustMite/dustmite.d DustMite/splitter.d -of$(@)
 
 #dreadful custom step because of libcurl dmd linking problem (Bugzilla 7044)
-$(CURL_TOOLS): $(ROOT)/%: %.d
-	$(DMD) $(MODEL_FLAG) $(DFLAGS) -c -of$(@).o $(<)
-# grep for the linker invocation and append -lcurl
-	LINKCMD=$$($(DMD) $(MODEL_FLAG) $(DFLAGS) -v -of$(@) $(@).o 2>/dev/null | grep $(@).o); \
-	$${LINKCMD} -lcurl
-
-$(TOOLS) $(DOC_TOOLS): $(ROOT)/%: %.d
+$(TOOLS) $(DOC_TOOLS) $(CURL_TOOLS): $(ROOT)/%: %.d
 	$(DMD) $(MODEL_FLAG) $(DFLAGS) -of$(@) $(<)
 
 ALL_OF_PHOBOS_DRUNTIME_AND_DLANG_ORG = # ???

--- a/travis.sh
+++ b/travis.sh
@@ -41,7 +41,7 @@ test_rdmd() {
 
 setup_repos()
 {
-    for repo in dmd druntime phobos dlang.org ; do
+    for repo in dmd druntime phobos dlang.org installer ; do
         if [ ! -d "../${repo}" ] ; then
             if [ $TRAVIS_BRANCH != master ] && [ $TRAVIS_BRANCH != stable ] &&
                    ! git ls-remote --exit-code --heads https://github.com/dlang/$proj.git $TRAVIS_BRANCH > /dev/null; then


### PR DESCRIPTION
As I wanted to enable a Travis CI compilation check for #203, I realized that further cleanup needs to be done. Thus here are the Travis CI enhancements - the commit messages should be explanatory.

I removed digger in favor of custom cloning as the `posix.mak` requires the typical dlang structure.