### PR TITLE
Rename phobos_test_extractor -> tests_extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,21 +8,21 @@ D tools
 This repository hosts various tools redistributed with DMD or used
 internally during various build tasks.
 
-Program                | Scope    | Description
----------------------- | -------- | -----------------------------------------
-catdoc                 | Build    | Concatenates Ddoc files.
-changed                | Internal | Change log generator.
-chmodzip               | Build    | ZIP file attributes editor.
-ddemangle              | Public   | D symbol demangler.
-detab                  | Internal | Replaces tabs with spaces.
-dget                   | Internal | D source code downloader.
-dman                   | Public   | D documentation lookup tool.
-dustmite               | Public   | [Test case minimization tool](https://github.com/CyberShadow/DustMite/wiki).
-get_dlibcurl32         | Internal | Win32 libcurl downloader/converter.
-phobos_tests_extractor | Internal | Extracts public unittests from Phobos (requires DUB)
-rdmd                   | Public   | [D build tool](http://dlang.org/rdmd.html).
-rdmd_test              | Internal | rdmd test suite.
-tolf                   | Internal | Line endings converter.
+Program         | Scope    | Description
+--------------- | -------- | -----------------------------------------
+catdoc          | Build    | Concatenates Ddoc files.
+changed         | Internal | Change log generator.
+chmodzip        | Build    | ZIP file attributes editor.
+ddemangle       | Public   | D symbol demangler.
+detab           | Internal | Replaces tabs with spaces.
+dget            | Internal | D source code downloader.
+dman            | Public   | D documentation lookup tool.
+dustmite        | Public   | [Test case minimization tool](https://github.com/CyberShadow/DustMite/wiki).
+get_dlibcurl32  | Internal | Win32 libcurl downloader/converter.
+tests_extractor | Internal | Extracts public unittests (requires DUB)
+rdmd            | Public   | [D build tool](http://dlang.org/rdmd.html).
+rdmd_test       | Internal | rdmd test suite.
+tolf            | Internal | Line endings converter.
 
 To report a problem or browse the list of open bugs, please visit the
 [bug tracker](http://issues.dlang.org/).

--- a/tests_extractor.d
+++ b/tests_extractor.d
@@ -1,10 +1,10 @@
 #!/usr/bin/env dub
 /+ dub.sdl:
-name "check_phobos"
+name "tests_extractor"
 dependency "libdparse" version="~>0.7.0-beta.2"
 +/
 /*
- * Parses all public unittests that are visible on dlang.org
+ * Parses all public unittests
  * (= annotated with three slashes)
  *
  * Copyright (C) 2016 by D Language Foundation
@@ -144,7 +144,7 @@ void main(string[] args)
 
     if (helpInfo.helpWanted)
     {
-        return defaultGetoptPrinter(`phobos_tests_extractor
+        return defaultGetoptPrinter(`tests_extractor
 Searches the input directory recursively for public unittest blocks, i.e.
 unittest blocks that are annotated with three slashes (///).
 The tests will be extracted as one file for each source file


### PR DESCRIPTION
There is no hard-coded dependency on Phobos and if we already host it in the `tools` repo, it might be better to have a "more generic" name.