### PR TITLE
Improve unittest extractor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.exe
 *.tag
 *.pdb
+.dub
 
 /generated
 GNUmakefile


### PR DESCRIPTION
Making the test extractor a bit more generic:

- automatically recognize module name 
- print single files to a file (`stdout` by default)