### PR TITLE
Upgrade libdparse to 0.7.0

### DIFF
--- a/styles/dub.sdl
+++ b/styles/dub.sdl
@@ -1,4 +1,4 @@
-dependency "libdparse" version="~>0.7.0-beta.2"
+dependency "libdparse" version="~>0.7.0"
 name "styles"
 targetType "executable"
 sourceFiles "utils.d"

--- a/styles/dub.selections.json
+++ b/styles/dub.selections.json
@@ -1,6 +1,6 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"libdparse": "0.7.0-beta.2"
+		"libdparse": "0.7.0"
 	}
 }


### PR DESCRIPTION
Bumps the version of libdparse to 0.7.0 which includes a couple of bug fixes and most importantly updates the support of the [new DIP 1000 `scope` syntax](https://github.com/Hackerpilot/libdparse/pull/125).