### PR TITLE
Test extractor: visit the entire AST tree

### DIFF
--- a/styles/tests_extractor.d
+++ b/styles/tests_extractor.d
@@ -54,11 +54,10 @@ class TestVisitor : ASTVisitor
 
     override void visit(const Declaration decl)
     {
-        if (decl.unittest_ !is null)
-        {
-           if (hasDdocHeader(sourceCode, decl))
-                print(decl.unittest_);
-        }
+        if (decl.unittest_ !is null && hasDdocHeader(sourceCode, decl))
+            print(decl.unittest_);
+
+        decl.accept(this);
     }
 
 private:


### PR DESCRIPTION
The test extractor visited only first-level declarations. With this fix, it looks at nested declarations as well.