### PR TITLE
Handle empty issue list more gently + avoid fetching the git remote directly

### DIFF
--- a/changed.d
+++ b/changed.d
@@ -94,8 +94,6 @@ auto getIssues(string revRange)
     import std.process : execute, pipeProcess, Redirect, wait;
     import std.regex : ctRegex, match, splitter;
 
-    enum gitNamespace = ["GIT_NAMESPACE": "changed"];
-
     // see https://github.com/github/github-services/blob/2e886f407696261bd5adfc99b16d36d5e7b50241/lib/services/bugzilla.rb#L155
     enum closedRE = ctRegex!(`((close|fix|address)e?(s|d)? )?(ticket|bug|tracker item|issue)s?:? *([\d ,\+&#and]+)`, "i");
 
@@ -105,11 +103,11 @@ auto getIssues(string revRange)
     {
         auto cmd = ["git", "-C", repo, "fetch", "--tags", "https://github.com/dlang/" ~ repo.baseName,
                            "+refs/heads/*:refs/remotes/upstream/*"];
-        auto p = pipeProcess(cmd, Redirect.stdout, gitNamespace);
+        auto p = pipeProcess(cmd, Redirect.stdout);
         enforce(wait(p.pid) == 0, "Failed to execute '%(%s %)'.".format(cmd));
 
         cmd = ["git", "-C", repo, "log", revRange];
-        p = pipeProcess(cmd, Redirect.stdout, gitNamespace);
+        p = pipeProcess(cmd, Redirect.stdout);
         scope(exit) enforce(wait(p.pid) == 0, "Failed to execute '%(%s %)'.".format(cmd));
 
         foreach (line; p.stdout.byLine())


### PR DESCRIPTION
When there are no issues in the git log, the bugzilla query is empty and thus all issues get loaded. This is  fix that solves the problem by simply returning earlier and thus not sending the Bugzilla query.
Also there's also the category "VisualD" on Bugzilla into which on might run as well (even though it's currently not on list of parsed repos).

Moreover, as dlang.org changelog scheme is without "v", there's another simple fix that prints the previous version with the "v" prefix.