### PR TITLE
fix issue 17198 - rdmd does not recompile when --extra-file is added

### DIFF
--- a/rdmd.d
+++ b/rdmd.d
@@ -412,6 +412,7 @@ private string getWorkPath(in string root, in string[] compilerFlags)
         if (irrelevantSwitches.canFind(flag)) continue;
         context.put(flag.representation);
     }
+    foreach (f; extraFiles) context.put(f.representation);
     auto digest = context.finish();
     string hash = toHexString(digest);
 


### PR DESCRIPTION
Was: #218. Now targetting stable.