### PR TITLE
Use alternative header for nightly builds

### DIFF
--- a/changed.d
+++ b/changed.d
@@ -415,7 +415,10 @@ Please supply a bugzilla version
             changedRepos.each!(r => r.changes.writeTextChangesHeader(w, r.headline));
 
             if (!revRange.empty)
-                w.put("$(BR)$(BIG $(RELATIVE_LINK2 bugfix-list, List of all bug fixes and enhancements in D $(VER).))\n\n");
+                if (useNightlyTemplate)
+                    w.put("$(BR)$(BIG $(RELATIVE_LINK2 bugfix-list, List of all upcoming bug fixes and enhancements.))\n\n");
+                else
+                    w.put("$(BR)$(BIG $(RELATIVE_LINK2 bugfix-list, List of all bug fixes and enhancements in D $(VER).))\n\n");
 
             w.put("$(HR)\n\n");
 


### PR DESCRIPTION
I didn't realize that when we provide different Makefile targets (with `BUILD_NIGHTLY`) we can override even more logic :)