### PR TITLE
Changed.d: Remove leading whitespace in changelog output

### DIFF
--- a/changed.d
+++ b/changed.d
@@ -278,28 +278,26 @@ void writeTextChangesBody(Entries, Writer)(Entries changes, Writer w, string hea
             {
                 if (inPara)
                 {
-                    w.put("    )\n");
+                    w.put(")\n");
                     inPara = false;
                 }
                 inCode = !inCode;
             }
             else if (!inCode && !inPara && !line.empty)
             {
-                w.put("    $(P\n");
+                w.put("$(P\n");
                 inPara = true;
             }
             else if (inPara && line.empty)
             {
-                w.put("    )\n");
+                w.put(")\n");
                 inPara = false;
             }
-            if (!line.empty)
-                w.put(inPara ? "        " : "    ");
             w.put(line);
             w.put("\n");
         }
         if (inPara)
-            w.put("    )\n");
+            w.put(")\n");
     }
 }
 


### PR DESCRIPTION
It seems like some macros like `CONSOLE` don't like whitespace indentation.

Before

![screenshot](https://cdn.pbrd.co/images/DTugTAedA.png)

After:

![screenshot](https://cdn.pbrd.co/images/3ZloiPRt7.png)

See also: https://github.com/dlang/phobos/pull/5001