### PR TITLE
osmodel.mak: Mention tools + dlang.org repos in the update reminder

### DIFF
--- a/osmodel.mak
+++ b/osmodel.mak
@@ -1,5 +1,6 @@
 # This Makefile snippet detects the OS and the architecture MODEL
-# Keep this file in sync between druntime, phobos, tools, and dmd repositories!
+# Keep this file in sync between dmd, druntime, phobos, dlang.org and tools
+# repositories!
 
 ifeq (,$(OS))
   uname_S:=$(shell uname -s)


### PR DESCRIPTION
- The `osmodel.mak` files weren't in sync
- Since a couple of weeks the `tools` and `dlang.org` repo use the same file

Btw this manual sync seems very error-prone and labour-intensive.
Why can't we do an `include $(DMD_DIR)/src/osmodel.mak`?