### PR TITLE
Issue 17262 - Better docs for rdmd

### DIFF
--- a/rdmd.d
+++ b/rdmd.d
@@ -809,6 +809,7 @@ addition to compiler options, rdmd recognizes the following options:
                      (needs dmd's option `-of` to be present)
   --man              open web browser on manual page
   --shebang          rdmd is in a shebang line (put as first argument)
+  --tmpdir           set an alternative temporary directory
 ".format(defaultCompiler, defaultExclusions);
 }
 


### PR DESCRIPTION
Seems like manually maintaining the docs is a bad idea ;-)

Any reason why e.g. [defaultGetoptPrinter](https://dlang.org/phobos/std_getopt.html#.defaultGetoptPrinter) wasn't used?