### PR TITLE
Sort changelog entry files by file name

### DIFF
--- a/changed.d
+++ b/changed.d
@@ -232,6 +232,7 @@ auto readTextChanges(string changelogDir)
 
     return dirEntries(changelogDir, SpanMode.shallow)
             .filter!(a => a.name().endsWith(".dd"))
+            .array.sort()
             .map!readChangelog
             .filter!(a => a.title.length > 0);
 }


### PR DESCRIPTION
This stabilizes the changelog order, preventing [non-deterministic website builds](http://dtest.dlang.io/results/8b8dd5c9930e01efce763ae18d9053a5bfb63ce4/dc5e167b034348d80b8fdadbb149a2426930c8e4/), and also allows ordering the entries manually by naming the files according to the desired lexicographical order.

CC @wilzbach