### PR TITLE
Rename update.sh to setup.sh and make it work with auto-boostraping

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -168,9 +168,10 @@ function update() {
 function makeWorld() {
 # First make dmd
     (
+        which dmd >/dev/null || BT="AUTO_BOOTSTRAP=1"
         cd "$wd/dmd/src" &&
-        $makecmd -f posix.mak clean MODEL=$model &&
-        $makecmd -f posix.mak -j $parallel MODEL=$model
+        $makecmd -f posix.mak clean MODEL=$model $BT &&
+        $makecmd -f posix.mak -j $parallel MODEL=$model $BT
     )
 
 # Update the running dmd version


### PR DESCRIPTION
This little tool worked great when setting up a completely new computer. It's quite underrated!

This diff gives it a more intuitive name and makes it work with no previously installed dmd.