### PR TITLE
Improve testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,16 @@ language: d
 d:
   - dmd
 sudo: false
-addons:
-  apt:
-    packages:
-    - g++-multilib
-    - libcurl3-gnutls:i386
-env:
-  - MODEL=32
-  - MODEL=64
+
+matrix:
+  include:
+    - env: MODEL=64
+    - env: MODEL=32
+      addons:
+        apt:
+          packages:
+            - g++-multilib
+            - libcurl4-openssl-dev:i386
 
 script:
   - ./travis.sh

--- a/dman.d
+++ b/dman.d
@@ -142,7 +142,7 @@ string CHeader(string topic)
     static string[] dmccmds =
     [
         "assert.h",     "complex.h",   "ctype.h",      "fenv.h",
-        "float.h",      "locale.h",    "math.h",       "setjmp.h,"
+        "float.h",      "locale.h",    "math.h",       "setjmp.h",
         "signal.h",     "stdarg.h",    "stddef.h",     "stdio.h",
         "stdlib.h",     "string.h",    "time.h",       "gc.h",
         "bios.h",       "cerror.h",    "disp.h",       "dos.h",

--- a/posix.mak
+++ b/posix.mak
@@ -30,7 +30,7 @@ endif
 # default include/link paths, override by setting DFLAGS (e.g. make -f posix.mak DFLAGS=-I/foo)
 DFLAGS = -I$(DRUNTIME_PATH)/import -I$(PHOBOS_PATH) \
 		 -L-L$(PHOBOS_PATH)/generated/$(OS)/release/$(MODEL) $(MODEL_FLAG)
-DFLAGS += -w
+DFLAGS += -w -de
 
 TOOLS = \
     $(ROOT)/rdmd \

--- a/posix.mak
+++ b/posix.mak
@@ -61,14 +61,7 @@ dustmite:  $(ROOT)/dustmite
 $(ROOT)/dustmite: DustMite/dustmite.d DustMite/splitter.d
 	$(DMD) $(DFLAGS) DustMite/dustmite.d DustMite/splitter.d -of$(@)
 
-#dreadful custom step because of libcurl dmd linking problem (Bugzilla 7044)
-$(CURL_TOOLS): $(ROOT)/%: %.d
-	$(DMD) $(DFLAGS) -c -of$(@).o $(<)
-# grep for the linker invocation and append -lcurl
-	LINKCMD=$$($(DMD) $(DFLAGS) -v -of$(@) $(@).o 2>/dev/null | grep $(@).o); \
-	$${LINKCMD} -lcurl
-
-$(TOOLS) $(DOC_TOOLS): $(ROOT)/%: %.d
+$(TOOLS) $(DOC_TOOLS) $(CURL_TOOLS): $(ROOT)/%: %.d
 	$(DMD) $(DFLAGS) -of$(@) $(<)
 
 ALL_OF_PHOBOS_DRUNTIME_AND_DLANG_ORG = # ???

--- a/travis.sh
+++ b/travis.sh
@@ -44,4 +44,5 @@ dub --version
 
 test_rdmd
 
+make -f posix.mak all DMD=$(which dmd)
 make -f posix.mak test DMD=$(which dmd)


### PR DESCRIPTION
Follow-up to https://github.com/dlang/tools/pull/238

> Maybe build tools with `-de`?

Good idea - especially with daily crons form Travis we should get notified when stuff breaks.

Supersedes https://github.com/dlang/tools/pull/233