### PR TITLE
Fix chmodzip

### DIFF
--- a/chmodzip.d
+++ b/chmodzip.d
@@ -26,16 +26,14 @@ int main(string[] args)
             zr.expand(de);
             writefln("name = %s", de.name);
             writefln("\tcomment = %s", de.comment);
-            writefln("\tmadeVersion = x%04x", de.madeVersion);
             writefln("\textractVersion = x%04x", de.extractVersion);
             writefln("\tflags = x%04x", de.flags);
             writefln("\tcompressionMethod = %d", de.compressionMethod);
             writefln("\tcrc32 = x%08x", de.crc32);
             writefln("\texpandedSize = %s", de.expandedSize);
             writefln("\tcompressedSize = %s", de.compressedSize);
-            writefln("\teattr = %03o, %03o", de.externalAttributes >> 16, de.externalAttributes & 0xFFFF);
+            writefln("\teattr = %03o, %03o", de.fileAttributes);
             writefln("\tiattr = %03o", de.internalAttributes);
-            //writefln("\tdate = %s", std.date.toString(std.date.toDtime(de.time)));
             writefln("\tdate = %s", SysTime(unixTimeToStdTime((de.time))));
         }
         return 0;
@@ -74,11 +72,10 @@ L1:
 
         foreach (member; members)
         {
-            if (de.name == member && ((de.externalAttributes >> 16) & octal!7777) != newattr)
+            if (de.name == member && (de.fileAttributes & octal!7777) != newattr)
             {
                 changes = true;
-                de._madeVersion = 0x317; // necessary or linux unzip will ignore attributes
-                de.externalAttributes = (de.externalAttributes & ~(octal!7777 << 16)) | (newattr << 16);
+                de.fileAttributes = de.fileAttributes & ~octal!7777 | newattr;
                 break;
             }
         }

--- a/travis.sh
+++ b/travis.sh
@@ -45,3 +45,4 @@ dub --version
 test_rdmd
 
 make -f posix.mak test DMD=$(which dmd)
+dmd -c chmodzip.d


### PR DESCRIPTION
RE https://github.com/dlang/tools/pull/233/files#r122169048

> I'm not sure about these changes - on one hand if the script wasn't building no idea if it was actually used any more, on the other hand this needs to work correctly so that unzipping .zip files on POSIX results in the correct attributes being set for files, and I doubt this is tested automatically anywhere right now. @MartinNowak ?

Is this script even used anywhere at `dlang`? I couldn't find it anywhere at `dlang`.
The [README is the only hit](https://github.com/search?l=&q=chmodzip+user%3Adlang&ref=advsearch&type=Code&utf8=%E2%9C%93)...
-> I would be in favor of simply removing this file.