### PR TITLE
rdmd: Update imports for --eval and --loop

### DIFF
--- a/rdmd.d
+++ b/rdmd.d
@@ -814,7 +814,7 @@ addition to compiler options, rdmd recognizes the following options:
 ".format(defaultCompiler, defaultExclusions);
 }
 
-// For --eval
+// For --eval and --loop
 immutable string importWorld = "
 module temporary;
 import std.stdio, std.algorithm, std.array, std.ascii, std.base64,
@@ -827,7 +827,7 @@ import std.stdio, std.algorithm, std.array, std.ascii, std.base64,
     std.math, std.mathspecial, std.mmfile,
     std.numeric, std.outbuffer, std.parallelism, std.path, std.process,
     std.random, std.range, std.regex, std.signals, std.socket,
-    std.stdint, std.stdio, std.stdiobase,
+    std.stdint, std.stdio,
     std.string, std.windows.syserror, std.system, std.traits, std.typecons,
     std.typetuple, std.uni, std.uri, std.utf, std.variant, std.xml, std.zip,
     std.zlib;


### PR DESCRIPTION
Looks like nobody is using --eval or --loop...