### PR TITLE
Run rdmd testsuite properly

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -36,6 +36,9 @@ DFLAGS = -I$(DRUNTIME_PATH)/import -I$(PHOBOS_PATH) \
 		 -L-L$(PHOBOS_PATH)/generated/$(OS)/release/$(MODEL) $(MODEL_FLAG)
 DFLAGS += -w -de
 
+# Default DUB flags (DUB uses a different architecture format)
+DUBFLAGS = --arch=$(subst 32,x86,$(subst 64,x86_64,$(MODEL)))
+
 TOOLS = \
     $(ROOT)/rdmd \
     $(ROOT)/ddemangle \
@@ -89,7 +92,8 @@ clean:
 $(ROOT)/tests_extractor: tests_extractor.d
 	mkdir -p $(ROOT)
 	$(DUB) build \
-		   --single $< --force --compiler=$(abspath $(DMD)) && mv ./tests_extractor $@
+		   --single $< --force --compiler=$(abspath $(DMD)) $(DUBFLAGS) \
+		   && mv ./tests_extractor $@
 
 ################################################################################
 # Build & run tests

--- a/posix.mak
+++ b/posix.mak
@@ -50,6 +50,9 @@ CURL_TOOLS = \
 DOC_TOOLS = \
     $(ROOT)/dman
 
+TEST_TOOLS = \
+    $(ROOT)/rdmd_test
+
 all: $(TOOLS) $(CURL_TOOLS) $(ROOT)/dustmite
 
 rdmd:      $(ROOT)/rdmd
@@ -65,7 +68,7 @@ dustmite:  $(ROOT)/dustmite
 $(ROOT)/dustmite: DustMite/dustmite.d DustMite/splitter.d
 	$(DMD) $(DFLAGS) DustMite/dustmite.d DustMite/splitter.d -of$(@)
 
-$(TOOLS) $(DOC_TOOLS) $(CURL_TOOLS): $(ROOT)/%: %.d
+$(TOOLS) $(DOC_TOOLS) $(CURL_TOOLS) $(TEST_TOOLS): $(ROOT)/%: %.d
 	$(DMD) $(DFLAGS) -of$(@) $(<)
 
 ALL_OF_PHOBOS_DRUNTIME_AND_DLANG_ORG = # ???
@@ -88,9 +91,19 @@ $(ROOT)/tests_extractor: tests_extractor.d
 	$(DUB) build \
 		   --single $< --force --compiler=$(abspath $(DMD)) && mv ./tests_extractor $@
 
-test: $(ROOT)/tests_extractor
+################################################################################
+# Build & run tests
+################################################################################
+
+test_tests_extractor: $(ROOT)/tests_extractor
 	$< -i ./test/tests_extractor/ascii.d | diff - ./test/tests_extractor/ascii.d.ext
 	$< -i ./test/tests_extractor/iteration.d | diff - ./test/tests_extractor/iteration.d.ext
+
+test_rdmd: $(ROOT)/rdmd_test $(ROOT)/rdmd
+	$< --compiler=$(abspath $(DMD))
+	$(DMD) $(DFLAGS) -unittest -main -run rdmd.d
+
+test: test_tests_extractor test_rdmd
 
 ifeq ($(WITH_DOC),yes)
 all install: $(DOC_TOOLS)

--- a/posix.mak
+++ b/posix.mak
@@ -104,7 +104,7 @@ test_tests_extractor: $(ROOT)/tests_extractor
 	$< -i ./test/tests_extractor/iteration.d | diff - ./test/tests_extractor/iteration.d.ext
 
 test_rdmd: $(ROOT)/rdmd_test $(ROOT)/rdmd
-	$< --compiler=$(abspath $(DMD))
+	$< --compiler=$(abspath $(DMD)) -m$(MODEL)
 	$(DMD) $(DFLAGS) -unittest -main -run rdmd.d
 
 test: test_tests_extractor test_rdmd

--- a/rdmd_test.d
+++ b/rdmd_test.d
@@ -356,7 +356,6 @@ void runTests()
 
     res = execute([rdmdApp, "--compiler=" ~ fullCompilerPath, forceSrc]);
     assert(res.status == 0, res.output ~ "\nCan't run with --compiler=" ~ fullCompilerPath);
-    assert(res.output.canFind("compile_force_src"));
 
     // Create an empty temporary directory and clean it up when exiting scope
     static struct TmpDir

--- a/rdmd_test.d
+++ b/rdmd_test.d
@@ -44,6 +44,8 @@ else
 
 string rdmdApp; // path/to/rdmd.exe (once built)
 string compiler = "dmd";  // e.g. dmd/gdmd/ldmd
+string model = "64"; // build architecture for dmd
+string[] rdmdArgs; // path to rdmd + common arguments (compiler, model)
 
 void main(string[] args)
 {
@@ -53,6 +55,7 @@ void main(string[] args)
         "compiler", &compiler,
         "rdmd", &rdmd,
         "concurrency", &concurrencyTest,
+        "m|model", &model,
     );
 
     enforce(rdmd.exists, "Path to rdmd does not exist: %s".format(rdmd));
@@ -60,10 +63,12 @@ void main(string[] args)
     rdmdApp = tempDir().buildPath("rdmd_app_") ~ binExt;
     if (rdmdApp.exists) std.file.remove(rdmdApp);
 
-    auto res = execute([compiler, "-of" ~ rdmdApp, rdmd]);
+    auto res = execute([compiler, modelSwitch, "-of" ~ rdmdApp, rdmd]);
 
     enforce(res.status == 0, res.output);
     enforce(rdmdApp.exists);
+
+    rdmdArgs = [rdmdApp, compilerSwitch, modelSwitch];
 
     runTests();
     if (concurrencyTest)
@@ -71,6 +76,7 @@ void main(string[] args)
 }
 
 @property string compilerSwitch() { return "--compiler=" ~ compiler; }
+@property string modelSwitch() { return "-m" ~ model; }
 
 void runTests()
 {
@@ -88,15 +94,15 @@ void runTests()
     string forceSrc = tempDir().buildPath("force_src_.d");
     std.file.write(forceSrc, `void main() { pragma(msg, "compile_force_src"); }`);
 
-    res = execute([rdmdApp, compilerSwitch, forceSrc]);
+    res = execute(rdmdArgs ~ [forceSrc]);
     assert(res.status == 0, res.output);
     assert(res.output.canFind("compile_force_src"));
 
-    res = execute([rdmdApp, compilerSwitch, forceSrc]);
+    res = execute(rdmdArgs ~ [forceSrc]);
     assert(res.status == 0, res.output);
     assert(!res.output.canFind("compile_force_src"));  // second call will not re-compile
 
-    res = execute([rdmdApp, compilerSwitch, "--force", forceSrc]);
+    res = execute(rdmdArgs ~ ["--force", forceSrc]);
     assert(res.status == 0, res.output);
     assert(res.output.canFind("compile_force_src"));  // force will re-compile
 
@@ -104,49 +110,49 @@ void runTests()
     string failRuntime = tempDir().buildPath("fail_runtime_.d");
     std.file.write(failRuntime, "void main() { assert(0); }");
 
-    res = execute([rdmdApp, compilerSwitch, "--force", "--build-only", failRuntime]);
+    res = execute(rdmdArgs ~ ["--force", "--build-only", failRuntime]);
     assert(res.status == 0, res.output);  // only built, assert(0) not called.
 
-    res = execute([rdmdApp, compilerSwitch, "--force", failRuntime]);
+    res = execute(rdmdArgs ~ ["--force", failRuntime]);
     assert(res.status == 1, res.output);  // assert(0) called, rdmd execution failed.
 
     string failComptime = tempDir().buildPath("fail_comptime_.d");
     std.file.write(failComptime, "void main() { static assert(0); }");
 
-    res = execute([rdmdApp, compilerSwitch, "--force", "--build-only", failComptime]);
+    res = execute(rdmdArgs ~ ["--force", "--build-only", failComptime]);
     assert(res.status == 1, res.output);  // building will fail for static assert(0).
 
-    res = execute([rdmdApp, compilerSwitch, "--force", failComptime]);
+    res = execute(rdmdArgs ~ ["--force", failComptime]);
     assert(res.status == 1, res.output);  // ditto.
 
     /* Test --chatty. */
     string voidMain = tempDir().buildPath("void_main_.d");
     std.file.write(voidMain, "void main() { }");
 
-    res = execute([rdmdApp, compilerSwitch, "--force", "--chatty", voidMain]);
+    res = execute(rdmdArgs ~ ["--force", "--chatty", voidMain]);
     assert(res.status == 0, res.output);
     assert(res.output.canFind("stat "));  // stat should be called.
 
     /* Test --dry-run. */
-    res = execute([rdmdApp, compilerSwitch, "--force", "--dry-run", failComptime]);
+    res = execute(rdmdArgs ~ ["--force", "--dry-run", failComptime]);
     assert(res.status == 0, res.output);  // static assert(0) not called since we did not build.
     assert(res.output.canFind("mkdirRecurse "), res.output);  // --dry-run implies chatty
 
-    res = execute([rdmdApp, compilerSwitch, "--force", "--dry-run", "--build-only", failComptime]);
+    res = execute(rdmdArgs ~ ["--force", "--dry-run", "--build-only", failComptime]);
     assert(res.status == 0, res.output);  // --build-only should not interfere with --dry-run
 
     /* Test --eval. */
-    res = execute([rdmdApp, compilerSwitch, "--force", "-de", "--eval=writeln(`eval_works`);"]);
+    res = execute(rdmdArgs ~ ["--force", "-de", "--eval=writeln(`eval_works`);"]);
     assert(res.status == 0, res.output);
     assert(res.output.canFind("eval_works"));  // there could be a "DMD v2.xxx header in the output"
 
     // compiler flags
-    res = execute([rdmdApp, compilerSwitch, "--force", "-debug",
+    res = execute(rdmdArgs ~ ["--force", "-debug",
         "--eval=debug {} else assert(false);"]);
     assert(res.status == 0, res.output);
 
     // vs program file
-    res = execute([rdmdApp, compilerSwitch, "--force",
+    res = execute(rdmdArgs ~ ["--force",
         "--eval=assert(true);", voidMain]);
     assert(res.status != 0);
     assert(res.output.canFind("Cannot have both --eval and a program file ('" ~
@@ -163,16 +169,16 @@ void runTests()
     std.file.write(subModSrc, "module dsubpack.submod; void foo() { }");
 
     // build an object file out of the dependency
-    res = execute([compiler, "-c", "-of" ~ subModObj, subModSrc]);
+    res = execute([compiler, modelSwitch, "-c", "-of" ~ subModObj, subModSrc]);
     assert(res.status == 0, res.output);
 
     string subModUser = tempDir().buildPath("subModUser_.d");
     std.file.write(subModUser, "module subModUser_; import dsubpack.submod; void main() { foo(); }");
 
-    res = execute([rdmdApp, compilerSwitch, "--force", "--exclude=dsubpack", subModUser]);
+    res = execute(rdmdArgs ~ ["--force", "--exclude=dsubpack", subModUser]);
     assert(res.status == 1, res.output);  // building without the dependency fails
 
-    res = execute([rdmdApp, compilerSwitch, "--force", "--exclude=dsubpack", subModObj, subModUser]);
+    res = execute(rdmdArgs ~ ["--force", "--exclude=dsubpack", subModObj, subModUser]);
     assert(res.status == 0, res.output);  // building with the dependency succeeds
 
     /* Test --include. */
@@ -186,10 +192,10 @@ void runTests()
 
     std.file.write(subModUser, "import std.foo; void main() { foobar(); }");
 
-    res = execute([rdmdApp, compilerSwitch, "--force", subModUser]);
+    res = execute(rdmdArgs ~ ["--force", subModUser]);
     assert(res.status == 1, res.output);  // building without the --include fails
 
-    res = execute([rdmdApp, compilerSwitch, "--force", "--include=std", subModUser]);
+    res = execute(rdmdArgs ~ ["--force", "--include=std", subModUser]);
     assert(res.status == 0, res.output);  // building with the --include succeeds
 
     /* Test --extra-file. */
@@ -202,10 +208,10 @@ void runTests()
     std.file.write(extraFileMain,
             "module extraFileMain_; import extraFile_; void main() { f(); }");
 
-    res = execute([rdmdApp, compilerSwitch, "--force", extraFileMain]);
+    res = execute(rdmdArgs ~ ["--force", extraFileMain]);
     assert(res.status == 1, res.output); // undefined reference to f()
 
-    res = execute([rdmdApp, compilerSwitch, "--force",
+    res = execute(rdmdArgs ~ ["--force",
             "--extra-file=" ~ extraFileD, extraFileMain]);
     assert(res.status == 0, res.output); // now OK
 
@@ -213,7 +219,7 @@ void runTests()
     {
     auto testLines = "foo\nbar\ndoo".split("\n");
 
-    auto pipes = pipeProcess([rdmdApp, compilerSwitch, "--force", "--loop=writeln(line);"], Redirect.stdin | Redirect.stdout);
+    auto pipes = pipeProcess(rdmdArgs ~ ["--force", "--loop=writeln(line);"], Redirect.stdin | Redirect.stdout);
     foreach (input; testLines)
         pipes.stdin.writeln(input);
     pipes.stdin.close();
@@ -230,7 +236,7 @@ void runTests()
     }
 
     // vs program file
-    res = execute([rdmdApp, compilerSwitch, "--force",
+    res = execute(rdmdArgs ~ ["--force",
         "--loop=assert(true);", voidMain]);
     assert(res.status != 0);
     assert(res.output.canFind("Cannot have both --loop and a program file ('" ~
@@ -244,13 +250,13 @@ void runTests()
     /+ res = execute([rdmdApp, " %s", noMain));
     assert(res.status == 1, res.output);  // main missing +/
 
-    res = execute([rdmdApp, compilerSwitch, "--main", noMain]);
+    res = execute(rdmdArgs ~ ["--main", noMain]);
     assert(res.status == 0, res.output);  // main added
 
     string intMain = tempDir().buildPath("int_main_.d");
     std.file.write(intMain, "int main(string[] args) { return args.length; }");
 
-    res = execute([rdmdApp, compilerSwitch, "--main", intMain]);
+    res = execute(rdmdArgs ~ ["--main", intMain]);
     assert(res.status == 1, res.output);  // duplicate main
 
     /* Test --makedepend. */
@@ -260,7 +266,7 @@ void runTests()
     string depMod = packRoot.buildPath("depMod_.d");
     std.file.write(depMod, "module depMod_; import dsubpack.submod; void main() { }");
 
-    res = execute([rdmdApp, compilerSwitch, "-I" ~ packRoot, "--makedepend",
+    res = execute(rdmdArgs ~ ["-I" ~ packRoot, "--makedepend",
             "-of" ~ depMod[0..$-2], depMod]);
 
     import std.ascii : newline;
@@ -278,7 +284,7 @@ void runTests()
     std.file.write(depModFail, "module depMod_; import dsubpack.submod; void main() { assert(0); }");
 
     string depMak = packRoot.buildPath("depMak_.mak");
-    res = execute([rdmdApp, compilerSwitch, "--force", "--build-only",
+    res = execute(rdmdArgs ~ ["--force", "--build-only",
             "-I" ~ packRoot, "--makedepfile=" ~ depMak,
             "-of" ~ depModFail[0..$-2], depModFail]);
     scope (exit) std.file.remove(depMak);
@@ -300,7 +306,7 @@ void runTests()
         import core.sys.posix.signal;
         string crashSrc = tempDir().buildPath("crash_src_.d");
         std.file.write(crashSrc, `void main() { int *p; *p = 0; }`);
-        res = execute([rdmdApp, compilerSwitch, crashSrc]);
+        res = execute(rdmdArgs ~ [crashSrc]);
         assert(res.status == -SIGSEGV, format("%s", res));
     }
 
@@ -316,7 +322,7 @@ void runTests()
 
     /* Current directory change should not trigger rebuild */
 
-    res = execute([rdmdApp, compilerSwitch, forceSrc]);
+    res = execute(rdmdArgs ~ [forceSrc]);
     assert(res.status == 0, res.output);
     assert(!res.output.canFind("compile_force_src"));
 
@@ -325,7 +331,7 @@ void runTests()
         scope(exit) chdir(cwd);
         chdir(tempDir);
 
-        res = execute([rdmdApp, compilerSwitch, forceSrc.baseName()]);
+        res = execute(rdmdArgs ~ [forceSrc.baseName()]);
         assert(res.status == 0, res.output);
         assert(!res.output.canFind("compile_force_src"));
     }
@@ -339,12 +345,12 @@ void runTests()
             rmdirRecurse(conflictDir);
     }
     mkdir(conflictDir);
-    res = execute([rdmdApp, compilerSwitch, "-of" ~ conflictDir, forceSrc]);
+    res = execute(rdmdArgs ~ ["-of" ~ conflictDir, forceSrc]);
     assert(res.status != 0, "-of set to a directory should fail");
 
     /* rdmd should force rebuild when --compiler changes: https://issues.dlang.org/show_bug.cgi?id=15031 */
 
-    res = execute([rdmdApp, compilerSwitch, forceSrc]);
+    res = execute(rdmdArgs ~ [forceSrc]);
     assert(res.status == 0, res.output);
     assert(!res.output.canFind("compile_force_src"));
 
@@ -382,11 +388,11 @@ void runTests()
 
     /* tmpdir */
     {
-        res = execute([rdmdApp, compilerSwitch, forceSrc, "--build-only"]);
+        res = execute(rdmdArgs ~ [forceSrc, "--build-only"]);
         assert(res.status == 0, res.output);
 
         TmpDir tmpdir = "rdmdTest";
-        res = execute([rdmdApp, compilerSwitch, "--tmpdir=" ~ tmpdir, forceSrc, "--build-only"]);
+        res = execute(rdmdArgs ~ ["--tmpdir=" ~ tmpdir, forceSrc, "--build-only"]);
         assert(res.status == 0, res.output);
         assert(res.output.canFind("compile_force_src"));
     }
@@ -398,7 +404,7 @@ void runTests()
         std.file.write(srcName, `void fun() {}`);
         if (exists("test" ~ libExt)) remove("test" ~ libExt);
 
-        res = execute([rdmdApp, compilerSwitch, "--build-only", "--force", "-lib", srcName]);
+        res = execute(rdmdArgs ~ ["--build-only", "--force", "-lib", srcName]);
         assert(res.status == 0, res.output);
         assert(exists(srcDir.buildPath("test" ~ libExt)));
         assert(!exists("test" ~ libExt));
@@ -412,7 +418,7 @@ void runTests()
         string srcName = srcDir.buildPath("test.d");
         std.file.write(srcName, `void fun() {}`);
 
-        res = execute([rdmdApp, compilerSwitch, "--build-only", "--force", "-lib", "-od" ~ libDir, srcName]);
+        res = execute(rdmdArgs ~ ["--build-only", "--force", "-lib", "-od" ~ libDir, srcName]);
         assert(res.status == 0, res.output);
         assert(exists(libDir.buildPath("test" ~ libExt)));
     }
@@ -426,7 +432,7 @@ void runTests()
         std.file.write(srcName, `void fun() {}`);
         string libName = libDir.buildPath("libtest" ~ libExt);
 
-        res = execute([rdmdApp, compilerSwitch, "--build-only", "--force", "-lib", "-of" ~ libName, srcName]);
+        res = execute(rdmdArgs ~ ["--build-only", "--force", "-lib", "-of" ~ libName, srcName]);
         assert(res.status == 0, res.output);
         assert(exists(libName));
     }
@@ -438,7 +444,7 @@ void runTests()
         std.file.write(srcName, `void main() {}`);
         string objName = srcDir.buildPath("test" ~ objExt);
 
-        res = execute([rdmdApp, compilerSwitch, "--force", "-c", srcName]);
+        res = execute(rdmdArgs ~ ["--force", "-c", srcName]);
         assert(res.status == 0, res.output);
         assert(exists(objName));
     }
@@ -451,24 +457,24 @@ void runTests()
         string libSrcName = srcDir.buildPath("libfun.d");
         std.file.write(libSrcName, `extern(C) void fun() {}`);
 
-        res = execute([rdmdApp, compilerSwitch, "-lib", libSrcName]);
+        res = execute(rdmdArgs ~ ["-lib", libSrcName]);
         assert(res.status == 0, res.output);
         assert(exists(srcDir.buildPath("libfun" ~ libExt)));
 
         string mainSrcName = srcDir.buildPath("main.d");
         std.file.write(mainSrcName, `extern(C) void fun(); pragma(lib, "fun"); void main() { fun(); }`);
 
-        res = execute([rdmdApp, compilerSwitch, "-L-L" ~ srcDir, mainSrcName]);
+        res = execute(rdmdArgs ~ ["-L-L" ~ srcDir, mainSrcName]);
         assert(res.status == 0, res.output);
     }}
 
     /* https://issues.dlang.org/show_bug.cgi?id=16966 */
     {
         immutable voidMainExe = setExtension(voidMain, binExt);
-        res = execute([rdmdApp, compilerSwitch, voidMain]);
+        res = execute(rdmdArgs ~ [voidMain]);
         assert(res.status == 0, res.output);
         assert(!exists(voidMainExe));
-        res = execute([rdmdApp, compilerSwitch, "--build-only", voidMain]);
+        res = execute(rdmdArgs ~ ["--build-only", voidMain]);
         assert(res.status == 0, res.output);
         assert(exists(voidMainExe));
         remove(voidMainExe);
@@ -483,13 +489,13 @@ void runTests()
         std.file.write(src1, "int x = 1; int main() { return x; }");
         std.file.write(src2, "import test; static this() { x = 0; }");
 
-        res = execute([rdmdApp, compilerSwitch, src1]);
+        res = execute(rdmdArgs ~ [src1]);
         assert(res.status == 1, res.output);
 
-        res = execute([rdmdApp, compilerSwitch, "--extra-file=" ~ src2, src1]);
+        res = execute(rdmdArgs ~ ["--extra-file=" ~ src2, src1]);
         assert(res.status == 0, res.output);
 
-        res = execute([rdmdApp, compilerSwitch, src1]);
+        res = execute(rdmdArgs ~ [src1]);
         assert(res.status == 1, res.output);
     }
 }
@@ -500,8 +506,8 @@ void runConcurrencyTest()
     std.file.write(sleep100, "void main() { import core.thread; Thread.sleep(100.msecs); }");
     auto argsVariants =
     [
-        [rdmdApp, compilerSwitch, sleep100],
-        [rdmdApp, compilerSwitch, "--force", sleep100],
+        rdmdArgs ~ [sleep100],
+        rdmdArgs ~ ["--force", sleep100],
     ];
     import std.parallelism, std.range, std.random;
     foreach (rnd; rndGen.parallel(1))

--- a/travis.sh
+++ b/travis.sh
@@ -10,18 +10,6 @@ if [ -z ${MODEL:-} ] ; then
     MODEL=64
 fi
 
-test_rdmd() {
-    # run rdmd internal tests
-    rdmd -m$MODEL -main -unittest rdmd.d
-
-    # compile rdmd & testsuite
-    dmd -m$MODEL rdmd.d
-    dmd -m$MODEL rdmd_test.d
-
-    # run rdmd testsuite
-    ./rdmd_test
-}
-
 build_digger() {
     git clone --recursive https://github.com/CyberShadow/Digger "$DIGGER_DIR"
     (cd "$DIGGER_DIR" && rdmd --build-only -debug digger)
@@ -41,8 +29,6 @@ install_digger
 dmd --version
 rdmd --help | head -n 1
 dub --version
-
-test_rdmd
 
 make -f posix.mak all DMD=$(which dmd)
 make -f posix.mak test DMD=$(which dmd)

--- a/travis.sh
+++ b/travis.sh
@@ -17,7 +17,7 @@ build_digger() {
 
 install_digger() {
     $DIGGER build --model=$MODEL "master"
-    export PATH=$PWD/result/bin:$PATH
+    export PATH=$PWD/work/result/bin:$PATH
 }
 
 if ! [ -d "$DIGGER_DIR" ] ; then


### PR DESCRIPTION
Follow-up to https://github.com/dlang/tools/pull/239#issuecomment-312869044

This should make (1) it a lot easier to run the test suite properly (after all it's now part of the `test` Makefile target) and (2) should be a good step into debugging why Travis build succeed.

Currently, however, it fails:

```
pmake test_rdmd
../dmd/generated/linux/release/64/dmd -I../druntime/import -I../phobos -L-L../phobos/generated/linux/release/64 -m64 -w -de -ofgenerated/linux/64/rdmd_test rdmd_test.d
../phobos/std/parallelism.d(3523): Warning: statement is not reachable
../phobos/std/parallelism.d(3523): Warning: statement is not reachable
make: *** [posix.mak:72: generated/linux/64/rdmd_test] Error 1
```

I have looked into fixing `rdmd_test` two weeks ago and the fix for this is still in the Phobos queue: https://github.com/dlang/phobos/pull/5502

CC @CyberShadow 