### PR TITLE
Upgrade libdparse (remove deprecation warnings)

### DIFF
--- a/tests_extractor.d
+++ b/tests_extractor.d
@@ -1,7 +1,7 @@
 #!/usr/bin/env dub
 /++dub.sdl:
 name "tests_extractor"
-dependency "libdparse" version="~>0.7.0-beta.4"
+dependency "libdparse" version="~>0.7.1-beta.5"
 +/
 /*
  * Parses all public unittests that are visible on dlang.org


### PR DESCRIPTION
In the spirit of removing deprecation warnings, s.t. they don't bite us later.

```
../../../.dub/packages/libdparse-0.7.0/libdparse/src/dparse/ast.d(1346,10): Deprecation: cannot implicitly override base class method object.Object.opEquals with dparse.ast.Declaration.opEquals; add override attribute
tests_extractor ~master: building configuration "application"...
../../../.dub/packages/libdparse-0.7.0/libdparse/src/dparse/ast.d(1346,10): Deprecation: cannot implicitly override base class method object.Object.opEquals with dparse.ast.Declaration.opEquals; add override attribute
```