### PR TITLE
Pin digger to a specific version

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -24,6 +24,7 @@ test_rdmd() {
 
 build_digger() {
     git clone --recursive https://github.com/CyberShadow/Digger "$DIGGER_DIR"
+    git -C "$DIGGER_DIR" checkout v3.0.0-alpha-5
     (cd "$DIGGER_DIR" && rdmd --build-only -debug digger)
 }
 


### PR DESCRIPTION
https://github.com/dlang/tools/pull/244/files#r125533867

> I'd suggest pinning Digger to a specific version (as with DScanner) to avoid the breaking changes in Digger's master from affecting tools.