### PR TITLE
tests_extractor: Ignore conditional declaration blocks

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -102,6 +102,7 @@ $(ROOT)/tests_extractor: tests_extractor.d
 test_tests_extractor: $(ROOT)/tests_extractor
 	$< -i ./test/tests_extractor/ascii.d | diff - ./test/tests_extractor/ascii.d.ext
 	$< -i ./test/tests_extractor/iteration.d | diff - ./test/tests_extractor/iteration.d.ext
+	$< -i ./test/tests_extractor/ignore_version.d | diff - ./test/tests_extractor/ignore_version.d.ext
 
 test_rdmd: $(ROOT)/rdmd_test $(ROOT)/rdmd
 	$< --compiler=$(abspath $(DMD)) -m$(MODEL)

--- a/test/tests_extractor/ignore_version.d
+++ b/test/tests_extractor/ignore_version.d
@@ -1,0 +1,4 @@
+/// Versioned blocks should be ignored
+version(StdDdoc)
+///
+@safe unittest {}

--- a/tests_extractor.d
+++ b/tests_extractor.d
@@ -64,6 +64,9 @@ class TestVisitor : ASTVisitor
         decl.accept(this);
     }
 
+    // ignore `version` blocks
+    override void visit(const ConditionalDeclaration decl) {}
+
 private:
     void print(const Unittest u)
     {


### PR DESCRIPTION
Currently the tests extractor looks at all public declarations. There is one instance Phobos (`std.digest.hmac`) where this leads to errors.

```
make  -f posix.mak std/digest/hmac.publictests
```

due to the module header example:

```d
version(StdDdoc)
/// Computes an HMAC over data read from stdin.
@safe unittest
{
 ...
    stdin.byChunk(4096)
...
```

this blocks and waits for input on the non-existing input on stdin.