### PR TITLE
Fix Issue 11997 - rdmd should search it's binary path for the compiler

### DIFF
--- a/changelog/b11997.dd
+++ b/changelog/b11997.dd
@@ -1,0 +1,13 @@
+rdmd now checks for a D compiler binary in the directory it's in first
+
+If you downloaded a zip/tar file with the compiler before
+and ran `rdmd`, it would invoke the D compiler from the system
+`PATH` rather than the compiler right next to it, failing if
+there wasn't one in the `PATH`. `rdmd` will now try to use
+the D compiler next to it first, and only fall back to the
+`PATH` if there isn't one adjacent. If you want rdmd to run a
+specific compiler, add the `--compiler` flag to force it, as
+always.
+
+To restore the old behaviour of only using the compiler from
+your `PATH`, add `--compiler=dmd` (or `ldmd2` or `gdmd`).

--- a/rdmd.d
+++ b/rdmd.d
@@ -59,6 +59,12 @@ version(unittest) {} else
 int main(string[] args)
 {
     //writeln("Invoked with: ", args);
+    // Look for the D compiler rdmd invokes automatically in the same directory as rdmd
+    // and fall back to using the one in your path otherwise.
+    string compilerPath = buildPath(dirName(thisExePath()), defaultCompiler);
+    if (compilerPath.exists && compilerPath.isFile)
+        compiler = compilerPath;
+
     if (args.length > 1 && args[1].startsWith("--shebang ", "--shebang="))
     {
         // multiple options wrapped in one

--- a/rdmd_test.d
+++ b/rdmd_test.d
@@ -310,6 +310,16 @@ void runTests()
         assert(res.status == -SIGSEGV, format("%s", res));
     }
 
+    /* https://issues.dlang.org/show_bug.cgi?id=11997- rdmd should search its
+    binary path for the compiler */
+    string localDMD = buildPath(tempDir(), baseName(compiler));
+    std.file.write(localDMD, "empty shell");
+    scope(exit) std.file.remove(localDMD);
+
+    res = execute(rdmdApp ~ [modelSwitch, "--force", "--chatty", "--eval=writeln(`Compiler found.`);"]);
+    assert(res.status == 1, res.output);
+    assert(res.output.canFind(`spawn ["` ~ localDMD ~ `",`));
+
     /* -of doesn't append .exe on Windows: https://d.puremagic.com/issues/show_bug.cgi?id=12149 */
 
     version (Windows)


### PR DESCRIPTION
`rdmd` should work out of the box now, without having to add it to your `PATH`, tested with dmd and ldc, which just started shipping with `rdmd`.  Would be nice to get this in before the final 2.075 release of dmd, pinging @MartinNowak.

Only drawback I can see is that if someone takes rdmd and puts it in some arbitrary directory with a file that's happened to be named `dmd` or `ldmd2`, `rdmd` will now try to run it.  Seems far-fetched, but the real solution is to just integrate `rdmd` with dmd and ldc, so this external script doesn't always have to go find them.