### PR TITLE
Add script to query for contributors between two releases

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,55 @@
+# See https://github.com/git/git/blob/master/Documentation/mailmap.txt
+adil <adil@stockopedia.co.uk>
+adil <adil@stockopedia.co.uk> <adil@adil-ThinkCentre-A85>
+aG0aep6G <aG0aep6G@users.noreply.github.com>
+Alex Rønne Petersen <alex@alexrp.com> <alex@lycus.org>
+amaury <deadalnix@gmail.com> <amaury@fb.com>
+Anders Ronnbrant <anders.ronnbrant@gmail.com>
+Andrej Mitrovic <andrej.mitrovich@gmail.com>
+Andrey Zherikov <andrey.zherikov@gmail.com>
+biotronic <simen.kjaras@gmail.com> <biotronic@biotronic.(none)>
+Brian Schott <briancschott@gmail.com>
+Christian Juelg <c.juelg@gmail.com>
+Clement Courbet <legrosbuffle@somebod.com> <clem@somebod.com>
+Daniel Murphy <yebblies@gmail.com>
+Dave Gallets <davegallets@gmail.com>
+David <admin@dav1d.de> <admin@dav1d.de>
+Denis Shelomovskij <verylonglogin.reg@gmail.com>
+Ed McCardell <edmccard@hotmail.com>
+Hara Kenji <k.hara.pg+dev@gmail.com> <k.hara.pg@gmail.com>
+Iain Buclaw <ibuclaw@gdcproject.org> <ibuclaw@HP-G62.(none)>
+Iain Buclaw <ibuclaw@gdcproject.org> ibuclaw <ibuclaw@ubuntu.com>
+Ilya Yaroshenko <ilyayaroshenko@gmail.com>
+Jacob Carlborg <doob@me.com> <jacob.carlborg@gmail.com>
+Jakob Øvrum <jakobovrum@gmail.com>
+Jakob Øvrum <jakobovrum@gmail.com> <JakobOvrum@users.noreply.github.com>
+John Colvin <john.loughran.colvin@gmail.com>
+Jonathan M Davis <jmdavisProg@gmx.com> <jonathan.davis@pelco.com>
+Jordi Sayol <g.sayol@yahoo.es>
+Kai Nacke <kai@redstar.de>
+kinke <noone@nowhere.com>
+Mark Barbone <30397247+mb64@users.noreply.github.com>
+Mark Barbone <30397247+mb64@users.noreply.github.com> Mark Barbone <>
+Martin Nowak <code@dawg.eu> <dawg@dawgfoto.de>
+Mathias Lang <mathias.lang@sociomantic.com> <geod24@gmail.com>
+Mathias Lang <mathias.lang@sociomantic.com> <mathias.lang@epitech.eu>
+Mathias Lang <mathias.lang@sociomantic.com> <pro.mathias.lang@gmail.com>
+monarchdodra <monarchdodra@gmail.com> <monarchdodra@gmail.com>
+Petar Kirov <petar.p.kirov@gmail.com> <petar.p.kirov@gmail.com>
+ponce <aliloko@gmail.com> <aliloko@gmail.com>
+Rainer Schuetze <r.sagitario@gmx.de> <r.sagitario@gmx.de>
+Razvan Nitu <razvan.nitu1305@gmail.com> <razvan.nitu1305@gmail.com>
+Robert burner Schadek <robert.schadek@informatik.uni-oldenburg.de> <rburners@gmail.com>
+Robert burner Schadek <robert.schadek@informatik.uni-oldenburg.de> <robert.schadek@informatik.uni-oldenburg.de>
+Safety0ff <safety0ff.dev@gmail.com>
+Safety0ff <safety0ff.dev@gmail.com> <safety0ff@users.sourceforge.net>
+shoo <zan77137@nifty.com> <zan77137@nifty.com>
+Stefan Koch <Uplink.Coder@googlemail.com>
+Stefan Rohe <think@hotmail.de>
+Timothee Cour <timothee.cour@gmail.com> <timothee.cour2@gmail.com>
+Torarin <torarin@gmail.com>
+Ulrich Küttler <kuettler@gmail.com>
+Walter Waldron <WalterWaldron@users.noreply.github.com>
+Yazan Dabain <yazan.dabain@arabiaweather.com> <yazan.dabain@gmail.com>
+Михаил Страшун <public@dicebot.lv> <m.strashun@gmail.com>
+Yao Gómez <yao.gomez@gmail.com> <yaoltzin@gmail.com>

--- a/contributors.d
+++ b/contributors.d
@@ -1,0 +1,163 @@
+#!/usr/bin/env rdmd
+
+/**
+Query contributors between two D releases.
+
+Copyright: D Language Foundation 2017.
+
+License:   $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
+
+Example usage:
+
+---
+./contributors.d "v2.074.0..v2.075.0"
+---
+
+Author: Sebastian Wilzbach
+*/
+
+import std.array;
+import std.algorithm;
+import std.conv;
+import std.exception;
+import std.file;
+import std.format;
+import std.process;
+import std.path;
+import std.range;
+import std.stdio;
+import std.string;
+import std.typecons;
+
+/// Name <my@email.com>
+struct GitAuthor
+{
+    string name, email;
+    string toString()
+    {
+        return "%s <%s>".format(name, email);
+    }
+}
+
+/// Reads a GitAuthor in the format of "Name <my@email.com>"
+GitAuthor readUser(string s)
+{
+    auto ps = s.splitter("<");
+    GitAuthor author = {
+        name: ps.front.to!string.strip,
+        email: ps.dropOne.front.filter!(a => a != '"').until('>').to!string
+    };
+    return author;
+}
+
+/// Options for finding authors
+struct FindConfig
+{
+    bool refreshTags; /// will query github.com for new tags
+    bool noMerges; // will ignore merge commits
+    bool showAllContributrs; // will ignore the revRange and show all contributors
+    string cwd; // working directory (should be tools)
+    string mailmapFile; // location to the .mailmap file
+}
+
+/**
+Search all git commit messages within revRange of all D repositories
+Returns: Array that maps each git `Author: ...` line to a GitAuthor
+*/
+auto findAuthors(string revRange, FindConfig config)
+{
+    Appender!(GitAuthor[]) authors;
+    int commits;
+    foreach (repo; ["dmd", "druntime", "phobos", "dlang.org", "tools", "installer"]
+             .map!(r => buildPath(config.cwd, "..", r)))
+    {
+        if (config.refreshTags)
+        {
+            auto cmd = ["git", "-C", repo, "fetch", "--tags", "https://github.com/dlang/" ~ repo.baseName,
+                               "+refs/heads/*:refs/remotes/upstream/*"];
+            auto p = pipeProcess(cmd, Redirect.stdout);
+            enforce(wait(p.pid) == 0, "Failed to execute '%(%s %)'.".format(cmd));
+        }
+
+        auto cmd = ["git", "-c", "mailmap.file=%s".format(config.mailmapFile), "-C", repo, "log", "--use-mailmap"];
+        if (!config.showAllContributrs)
+            cmd ~= revRange;
+        if (config.noMerges)
+            cmd ~= "--no-merges";
+
+        auto p = pipeProcess(cmd, Redirect.stdout);
+        scope(exit) enforce(wait(p.pid) == 0, "Failed to execute '%(%s %)'.".format(cmd));
+
+        static immutable Author = "Author: ";
+        p.stdout
+            .byLineCopy
+            .filter!(line => line.startsWith(Author))
+            .tee!(_ => commits++)
+            .map!((line){
+                line.skipOver(Author);
+                return line.readUser;
+            })
+            .filter!(a => a.name != "The Dlang Bot")
+            .each!(author => authors ~= author);
+    }
+    if (!config.showAllContributrs)
+        stderr.writefln("Looked at %d commits in %s", commits, revRange);
+    else
+        stderr.writefln("Looked at %d commits", commits);
+    return authors.data;
+}
+
+/// Sorts the authors and filters for duplicates
+auto reduceAuthors(GitAuthors)(GitAuthors authors)
+{
+    import std.uni : sicmp;
+    return authors
+            .sort!((a, b) => sicmp(a.name, b.name) < 0)
+            .release
+            .uniq!((a, b) => a.name == b.name);
+}
+
+int main(string[] args)
+{
+    import std.getopt;
+    string revRange;
+    FindConfig config = {
+        cwd: __FILE_FULL_PATH__.dirName.asNormalizedPath.to!string,
+    };
+    config.mailmapFile = config.cwd.buildPath(".mailmap");
+
+    enum PrintMode { name, markdown, ddoc, csv, git}
+    PrintMode printMode;
+
+    auto helpInformation = getopt(
+        args,
+        std.getopt.config.passThrough,
+        "f|format", "Result format (name, markdown, ddoc, csv, git)", &printMode,
+        "a|all", "Show all contributors", &config.showAllContributrs,
+        "refresh-tags", "Refresh tags", &config.refreshTags,
+        "no-merges", "Ignore merge commits", &config.noMerges,
+    );
+
+    if (helpInformation.helpWanted || (args.length < 2 && !config.showAllContributrs))
+    {
+`D contributors extractor.
+./contributors.d "v2.075.0..v2.076.0"`.defaultGetoptPrinter(helpInformation.options);
+        return 1;
+    }
+
+    revRange = args.length > 1 ? args[1] : null;
+    revRange.findAuthors(config)
+            .reduceAuthors
+            .each!((a){
+                with(PrintMode)
+                final switch (printMode)
+                {
+                    case name: a.name.writeln; break;
+                    case markdown: writefln("- %s", a.name); break;
+                    case ddoc: writefln("$(D_CONTRIBUTOR %s)", a.name); break;
+                    case csv: writefln("%s, %s", a.name, a.email); break;
+                    case git: writefln("%s <%s>", a.name, a.email); break;
+                }
+            });
+    return 0;
+}

--- a/contributors.d
+++ b/contributors.d
@@ -89,7 +89,7 @@ auto findAuthors(string revRange, FindConfig config)
         scope(exit) enforce(wait(p.pid) == 0, "Failed to execute '%(%s %)'.".format(cmd));
 
         static immutable Author = "Author: ";
-        p.stdout
+        authors ~= p.stdout
             .byLineCopy
             .filter!(line => line.startsWith(Author))
             .tee!(_ => commits++)
@@ -97,8 +97,7 @@ auto findAuthors(string revRange, FindConfig config)
                 line.skipOver(Author);
                 return line.readUser;
             })
-            .filter!(a => a.name != "The Dlang Bot")
-            .each!(author => authors ~= author);
+            .filter!(a => a.name != "The Dlang Bot");
     }
     if (!config.showAllContributrs)
         stderr.writefln("Looked at %d commits in %s", commits, revRange);
@@ -113,7 +112,6 @@ auto reduceAuthors(GitAuthors)(GitAuthors authors)
     import std.uni : sicmp;
     return authors
             .sort!((a, b) => sicmp(a.name, b.name) < 0)
-            .release
             .uniq!((a, b) => a.name == b.name);
 }
 

--- a/posix.mak
+++ b/posix.mak
@@ -42,6 +42,7 @@ DUBFLAGS = --arch=$(subst 32,x86,$(subst 64,x86_64,$(MODEL)))
 TOOLS = \
     $(ROOT)/catdoc \
     $(ROOT)/checkwhitespace \
+    $(ROOT)/contributors \
     $(ROOT)/ddemangle \
     $(ROOT)/detab \
     $(ROOT)/rdmd \


### PR DESCRIPTION
I don't know yet how we are going to integrate this on dlang.org, but this script should be more than flexible enough to accompany many possible scenarios.

Ideas:
- Add to the bottom of each changelog
- Separate page for each changelog (linked from changelog) (that's how [the Rails people](http://contributors.rubyonrails.org/) or [the Rust people handle this](https://thanks.rust-lang.org/rust/1.19.0))
- All contributors page (the tool is more than fast enough, s.t. we could run this on every deploy)