### PR TITLE
dman: Use d-tags.json instead of d.tag

### DIFF
--- a/dman.d
+++ b/dman.d
@@ -128,12 +128,13 @@ string DmcCommands(string topic)
 
 string D(string topic)
 {
-    static struct IndexEntry { string keyword; string[] urls; }
-    static IndexEntry[] entries = mixin (import("d.tag"));
+    static immutable tagJson = import("d-tags.json");
 
-    foreach (entry; entries)
-        if (entry.keyword == topic && entry.urls.length)
-            return entry.urls[0];
+    import std.json;
+    JSONValue tags = parseJSON(tagJson);
+
+    if (topic in tags && tags[topic].array.length)
+        return tags[topic][0].str;
 
     return null;
 }

--- a/posix.mak
+++ b/posix.mak
@@ -77,10 +77,10 @@ $(TOOLS) $(DOC_TOOLS) $(CURL_TOOLS) $(TEST_TOOLS): $(ROOT)/%: %.d
 
 ALL_OF_PHOBOS_DRUNTIME_AND_DLANG_ORG = # ???
 
-$(DOC)/d.tag : $(ALL_OF_PHOBOS_DRUNTIME_AND_DLANG_ORG)
-	${MAKE} --directory=${DOC} -f posix.mak d.tag
+$(DOC)/d-tags.json : $(ALL_OF_PHOBOS_DRUNTIME_AND_DLANG_ORG)
+	${MAKE} --directory=${DOC} -f posix.mak d-tags.json
 
-$(ROOT)/dman: $(DOC)/d.tag
+$(ROOT)/dman: $(DOC)/d-tags.json
 $(ROOT)/dman: DFLAGS += -J$(DOC)
 
 install: $(TOOLS) $(CURL_TOOLS) $(ROOT)/dustmite

--- a/win32.mak
+++ b/win32.mak
@@ -54,10 +54,10 @@ dustmite:  $(ROOT)\dustmite.exe
 
 ALL_OF_PHOBOS_DRUNTIME_AND_DLANG_ORG = # ???
 
-$(DOC)\d.tag : $(ALL_OF_PHOBOS_DRUNTIME_AND_DLANG_ORG)
-	cmd /C "cd $(DOC) && $(MAKE) -f win32.mak d.tag"
+$(DOC)\d-tags.json : $(ALL_OF_PHOBOS_DRUNTIME_AND_DLANG_ORG)
+	cmd /C "cd $(DOC) && $(MAKE) -f win32.mak d-tags.json"
 
-$(ROOT)\dman.exe : dman.d $(DOC)\d.tag
+$(ROOT)\dman.exe : dman.d $(DOC)\d-tags.json
 	$(DMD) $(DFLAGS) -of$@ dman.d -J$(DOC)
 
 $(ROOT)\rdmd.exe : rdmd.d


### PR DESCRIPTION
Needs https://github.com/dlang/dlang.org/pull/1860.

Fixes issue 17731.