### PR TITLE
Fix it so that DustMite uses std.datetime.stopwatch.

### DIFF
--- a/DustMite/dustmite.d
+++ b/DustMite/dustmite.d
@@ -9,6 +9,7 @@ import std.array;
 import std.ascii;
 import std.conv;
 import std.datetime;
+import std.datetime.stopwatch : StopWatch;
 import std.exception;
 import std.file;
 import std.getopt;
@@ -278,7 +279,7 @@ EOS");
 	else
 		reduce();
 
-	auto duration = cast(Duration)times.total.peek();
+	auto duration = times.total.peek();
 	duration = dur!"msecs"(duration.total!"msecs"); // truncate anything below ms, users aren't interested in that
 	if (foundAnything)
 	{
@@ -296,7 +297,7 @@ EOS");
 
 	if (showTimes)
 		foreach (i, t; times.tupleof)
-			writefln("%s: %s", times.tupleof[i].stringof, cast(Duration)times.tupleof[i].peek());
+			writefln("%s: %s", times.tupleof[i].stringof, times.tupleof[i].peek());
 
 	return 0;
 }


### PR DESCRIPTION
The old StopWatch, which uses TickDuration, is being deprecated. So, any
code using the old StopWatch needs to be updated to use the new one
(which uses MonoTime and Duration).

The casts are no longer necessary, because peek now returns a Duration
instead of a TickDuration.