### PR TITLE
leave it to user to build d-tags.json

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -75,13 +75,15 @@ $(ROOT)/dustmite: DustMite/dustmite.d DustMite/splitter.d
 $(TOOLS) $(DOC_TOOLS) $(CURL_TOOLS) $(TEST_TOOLS): $(ROOT)/%: %.d
 	$(DMD) $(DFLAGS) -of$(@) $(<)
 
-ALL_OF_PHOBOS_DRUNTIME_AND_DLANG_ORG = # ???
+d-tags.json:
+	@echo 'Build d-tags.json and copy it here, e.g. by running:'
+	@echo "    make -C ../dlang.org -f posix.mak d-tags-latest.json && cp ../dlang.org/d-tags-latest.json d-tags.json"
+	@echo 'or:'
+	@echo "    make -C ../dlang.org -f posix.mak d-tags-prerelease.json && cp ../dlang.org/d-tags-prerelease.json d-tags.json"
+	@exit 1
 
-$(DOC)/d-tags.json : $(ALL_OF_PHOBOS_DRUNTIME_AND_DLANG_ORG)
-	${MAKE} --directory=${DOC} -f posix.mak d-tags.json
-
-$(ROOT)/dman: $(DOC)/d-tags.json
-$(ROOT)/dman: DFLAGS += -J$(DOC)
+$(ROOT)/dman: d-tags.json
+$(ROOT)/dman: DFLAGS += -J.
 
 install: $(TOOLS) $(CURL_TOOLS) $(ROOT)/dustmite
 	mkdir -p $(INSTALL_DIR)/bin

--- a/win32.mak
+++ b/win32.mak
@@ -1,4 +1,3 @@
-DOC=..\dlang.org
 # Where scp command copies to
 SCPDIR=..\backup
 
@@ -52,13 +51,13 @@ ddemangle: $(ROOT)\ddemangle.exe
 changed:   $(ROOT)\changed.exe
 dustmite:  $(ROOT)\dustmite.exe
 
-ALL_OF_PHOBOS_DRUNTIME_AND_DLANG_ORG = # ???
-
-$(DOC)\d-tags.json : $(ALL_OF_PHOBOS_DRUNTIME_AND_DLANG_ORG)
-	cmd /C "cd $(DOC) && $(MAKE) -f win32.mak d-tags.json"
+d-tags.json :
+	@echo 'Build d-tags.json and copy it here, e.g. by running:'
+	@echo "    make -C ../dlang.org -f win32.mak d-tags.json && copy ../dlang.org/d-tags-latest.json d-tags.json"
+	@exit
 
 $(ROOT)\dman.exe : dman.d $(DOC)\d-tags.json
-	$(DMD) $(DFLAGS) -of$@ dman.d -J$(DOC)
+	$(DMD) $(DFLAGS) -of$@ dman.d -J.
 
 $(ROOT)\rdmd.exe : rdmd.d
 	$(DMD) $(DFLAGS) -of$@ rdmd.d advapi32.lib


### PR DESCRIPTION
- fixes remaking dlang.org when tool's Makefile is used by build scripts
- allows to build dman for prereleases, latest, or releases

Win rule untested!