### PR TITLE
add buildsdk: tool to create COFF import libraries from MinGW def files

### DIFF
--- a/winsdk/buildsdk.d
+++ b/winsdk/buildsdk.d
@@ -1,0 +1,184 @@
+//
+// Convert MingGW definition files to COFF import librries
+//
+// Distributed under the Boost Software License, Version 1.0.
+//   (See accompanying file LICENSE_1_0.txt or copy at
+//         http://www.boost.org/LICENSE_1_0.txt)
+//
+// usage: buildsdk [x86|x64] [def-folder] [output-folder] [msvcrt.def.in]
+//
+// Source files extracted from the MinGW reositories
+//
+// def-folder:    https://sourceforge.net/p/mingw/mingw-org-wsl/ci/5.0-active/tree/w32api/lib/
+// msvcrt.def.in: https://sourceforge.net/p/mingw/mingw-org-wsl/ci/5.0-active/tree/mingwrt/msvcrt-xref/msvcrt.def.in
+//
+// assumes VC tools cl,link,lib and ml installed and found through path
+//  and configured to the appropriate architecture
+//
+
+import std.file;
+import std.regex;
+import std.string;
+import std.stdio;
+import std.path;
+import std.process;
+import std.algorithm;
+
+version = verbose;
+
+void runShell(string cmd)
+{
+    version(verbose)
+        writeln(cmd);
+    auto rc = executeShell(cmd);
+    if (rc.status)
+    {
+        writeln("'", cmd, "' failed with status ", rc.status);
+        writeln(rc.output);
+        throw new Exception("'" ~ cmd ~ "' failed");
+    }
+}
+
+// x86: the exported symbols have stdcall mangling (including trailing @n)
+// but the internal names of the platform DLLs have names with @n stripped off
+// lib /DEF doesn't support renaming symbols so we have to go through compiling
+// a C file with the symbols and building a DLL with renamed exports to get
+// the appropriate import library
+//
+// x64: strip any @ from the symbol names
+bool def2implib(bool x64, string f, string dir)
+{
+    static auto re = regex(r"@?([a-zA-Z0-9_]+)(@[0-9]*)");
+    char[] content = cast(char[])std.file.read(f);
+    auto pos = content.indexOf("EXPORTS");
+    if (pos < 0)
+        return false;
+
+    char[] def = content[0..pos];
+    char[] csrc;
+    bool[string] written;
+    auto lines = content[pos..$].splitLines;
+    foreach(line; lines)
+    {
+        line = line.strip;
+        if (line.length == 0 || line[0] == ';')
+            continue;
+        const(char)[] sym;
+        char[] cline;
+        auto m = matchFirst(line, re);
+        if (m)
+        {
+            if (x64)
+                def ~= m[1] ~ "\n";
+            else
+                def ~= m[0] ~ "=" ~  m[1] ~ "\n";
+            sym = m[1];
+            cline = "void " ~ m[1] ~ "() {}\n";
+        }
+        else
+        {
+            def ~= line ~ "\n";
+            if (line.endsWith(" DATA"))
+            {
+                sym = strip(line[0..$-5]);
+                cline = "int " ~ sym ~ ";\n";
+            }
+            else
+            {
+                auto idx = line.indexOf('=');
+                if (idx > 0)
+                    sym = line[idx+1 .. $].strip;
+                else
+                    sym = line;
+                cline = "void " ~ sym ~ "() {}\n";
+            }
+        }
+        if(sym.length && sym !in written)
+        {
+            csrc ~= cline;
+            written[sym.idup] = true;
+        }
+    }
+    string base = stripExtension(baseName(f));
+    string dirbase = dir ~ base;
+    std.file.write(dirbase ~ ".def", def);
+    std.file.write(dirbase ~ ".c", csrc);
+
+    runShell("cl /c /Fo" ~ dirbase ~ ".obj " ~ dirbase ~ ".c");
+    runShell("link /NOD /NOENTRY /DLL " ~ dirbase ~ ".obj /out:" ~ dirbase ~ ".dll /def:" ~ dirbase ~ ".def");
+
+    // cleanup
+    std.file.remove(dirbase ~ ".def");
+    std.file.remove(dirbase ~ ".c");
+    std.file.remove(dirbase ~ ".obj");
+    std.file.remove(dirbase ~ ".dll");
+    std.file.remove(dirbase ~ ".exp");
+    return true;
+}
+
+void buildLibs(bool x64, string defdir, string dir)
+{
+    mkdirRecurse(dir ~ "ddk");
+
+    //goto LnoDef;
+    foreach(f; std.file.dirEntries("def", SpanMode.shallow))
+        if (extension(f).toLower == ".def")
+            def2implib(x64, f, dir);
+    foreach(f; std.file.dirEntries("def/directx", SpanMode.shallow))
+        if (extension(f).toLower == ".def")
+            def2implib(x64, f, dir);
+
+    foreach(f; std.file.dirEntries("def/ddk", SpanMode.shallow))
+        if (extension(f).toLower == ".def")
+            def2implib(x64, f, dir ~ "ddk/");
+}
+
+void buildMsvcrt(bool x64, string dir, string msvcdef)
+{
+    string arch = x64 ? "x64" : "x86";
+    string ml = x64 ? "ml64" : "ml";
+    string lib = "lib /MACHINE:" ~ arch ~ " ";
+    string msvcrtlib = "msvcrt51.lib";
+
+    // build msvcrt.lib for WinXP
+    runShell("cl /EP -D__MSVCRT_VERSION__=0x0501UL -D__DLLNAME__=msvcrt " ~ msvcdef ~ " >" ~ dir ~ "msvcrt.def");
+    runShell(lib ~ "/OUT:" ~ dir ~ msvcrtlib ~ " /DEF:" ~ dir ~ "msvcrt.def"); // no translation necessary
+    runShell("cl /c /Zl /Fo" ~ dir ~ "msvcrt_stub0.obj /D_APPTYPE=0 msvcrt_stub.c");
+    runShell("cl /c /Zl /Fo" ~ dir ~ "msvcrt_stub1.obj /D_APPTYPE=1 msvcrt_stub.c");
+    runShell("cl /c /Zl /Fo" ~ dir ~ "msvcrt_stub2.obj /D_APPTYPE=2 msvcrt_stub.c");
+    runShell("cl /c /Zl /Fo" ~ dir ~ "msvcrt_data.obj msvcrt_data.c");
+    runShell(ml ~ " /c /Fo" ~ dir ~ "msvcrt_abs.obj msvcrt_abs.asm");
+    auto files = ["msvcrt_abs.obj", "msvcrt_stub0.obj", "msvcrt_stub1.obj", "msvcrt_stub2.obj", "msvcrt_data.obj" ];
+    auto objs = files.map!(a => dir ~ a).join(" ");
+    runShell(lib ~ dir ~ msvcrtlib ~ " " ~ objs);
+
+    // create empty oldnames.lib (expected by dmd)
+    std.file.write(dir ~ "empty.c", "");
+    runShell("cl /c /Zl /Fo" ~ dir ~ "oldnames.obj " ~ dir ~ "empty.c");
+    runShell(lib ~ "/OUT:" ~ dir ~ "oldnames.lib " ~ dir ~ "oldnames.obj");
+
+    // create empty uuid.lib (expected by dmd, but UUIDs already in druntime)
+    runShell("cl /c /Zl /Fo" ~ dir ~ "uuid.obj " ~ dir ~ "empty.c");
+    runShell(lib ~ "/OUT:" ~ dir ~ "uuid.lib " ~ dir ~ "uuid.obj");
+
+    foreach(f; files)
+        std.file.remove(dir ~ f);
+    std.file.remove(dir ~ stripExtension(msvcrtlib) ~ ".exp");
+    std.file.remove(dir ~ "msvcrt.def");
+    std.file.remove(dir ~ "oldnames.obj");
+    std.file.remove(dir ~ "uuid.obj");
+    std.file.remove(dir ~ "empty.c");
+}
+
+void main(string[] args)
+{
+    bool x64 = (args.length > 1 && args[1] == "x64");
+    string defdir = (args.length > 2 ? args[2] : "def");
+    string outdir = x64 ? "lib64/" : "lib32mscoff/";
+    if (args.length > 3)
+        outdir = args[3] ~ "/";
+    string msvcdef = (args.length > 4 ? args[4] : "msvcrt.def.in");
+
+    buildLibs(x64, defdir, outdir);
+    buildMsvcrt(x64, outdir, msvcdef);
+}

--- a/winsdk/msvcrt_abs.asm
+++ b/winsdk/msvcrt_abs.asm
@@ -1,0 +1,8 @@
+
+public __except_list
+public __tls_array
+
+__except_list EQU 0
+__tls_array EQU 02ch
+
+end

--- a/winsdk/msvcrt_data.c
+++ b/winsdk/msvcrt_data.c
@@ -1,0 +1,58 @@
+#include <windows.h>
+
+#define _CRTALLOC(x) __declspec(allocate(x))
+
+ULONG _tls_index = 0;
+
+#pragma section(".tls")
+#pragma section(".tls$AAA")
+#pragma section(".tls$ZZZ")
+#pragma section(".CRT$XLA")
+#pragma section(".CRT$XLZ")
+#pragma section(".CRT$XIA")
+#pragma section(".CRT$XIZ")
+#pragma section(".CRT$XCA")
+#pragma section(".CRT$XCZ")
+#pragma section(".CRT$XPA")
+#pragma section(".CRT$XPZ")
+#pragma section(".CRT$XTA")
+#pragma section(".CRT$XTZ")
+
+/* TLS raw template data start and end. */
+_CRTALLOC(".tls$AAA") char _tls_start = 0;
+_CRTALLOC(".tls$ZZZ") char _tls_end = 0;
+
+// TLS init/exit callbacks
+_CRTALLOC(".CRT$XLA") PIMAGE_TLS_CALLBACK __xl_a = 0;
+_CRTALLOC(".CRT$XLZ") PIMAGE_TLS_CALLBACK __xl_z = 0;
+
+// #pragma section(".tls")
+_CRTALLOC(".tls") const IMAGE_TLS_DIRECTORY _tls_used =
+{
+  (SIZE_T) &_tls_start,
+  (SIZE_T) &_tls_end,
+  (SIZE_T) &_tls_index,
+  (SIZE_T) (&__xl_a+1),
+  (ULONG) 0, // SizeOfZeroFill
+  (ULONG) 0 // Characteristics
+};
+
+typedef void(*_PVFV)();
+
+// C init
+_CRTALLOC(".CRT$XIA") _PVFV __xi_a[] = { NULL };
+_CRTALLOC(".CRT$XIZ") _PVFV __xi_z[] = { NULL };
+// C++ init
+_CRTALLOC(".CRT$XCA") _PVFV __xc_a[] = { NULL };
+_CRTALLOC(".CRT$XCZ") _PVFV __xc_z[] = { NULL };
+// C pre-terminators
+_CRTALLOC(".CRT$XPA") _PVFV __xp_a[] = { NULL };
+_CRTALLOC(".CRT$XPZ") _PVFV __xp_z[] = { NULL };
+// C terminators
+_CRTALLOC(".CRT$XTA") _PVFV __xt_a[] = { NULL };
+_CRTALLOC(".CRT$XTZ") _PVFV __xt_z[] = { NULL };
+
+char _fltused;
+
+int    _argc = 0;
+char **_argv = NULL;

--- a/winsdk/msvcrt_stub.c
+++ b/winsdk/msvcrt_stub.c
@@ -1,0 +1,110 @@
+#include <windows.h>
+
+#define _CRTALLOC(x) __declspec(allocate(x))
+
+#define __UNKNOWN_APP    0 // abused for DLL
+#define __CONSOLE_APP    1
+#define __GUI_APP        2
+
+#ifndef _APPTYPE
+#define _APPTYPE __CONSOLE_APP
+#endif
+
+typedef void(*_PVFV)();
+
+// C init
+extern _PVFV __xi_a[];
+extern _PVFV __xi_z[];
+// C++ init
+extern _PVFV __xc_a[];
+extern _PVFV __xc_z[];
+// C pre-terminators
+extern _PVFV __xp_a[];
+extern _PVFV __xp_z[];
+// C terminators
+extern _PVFV __xt_a[];
+extern _PVFV __xt_z[];
+
+extern int main (int, char **, char **);
+extern void _setargv (void);
+
+extern IMAGE_DOS_HEADER __ImageBase; // linker generated
+
+#if _APPTYPE == __UNKNOWN_APP
+BOOL WINAPI
+DllMainCRTStartup (HANDLE hDll, DWORD dwReason, LPVOID lpReserved)
+{
+    BOOL bRet;
+
+    if (dwReason == DLL_PROCESS_ATTACH)
+    {
+        _initterm_e(__xi_a, __xi_z);
+        _initterm(__xc_a, __xc_z);
+    }
+
+    bRet = DllMain (hDll, dwReason, lpReserved);
+  
+    if (dwReason == DLL_PROCESS_ATTACH || dwReason == DLL_PROCESS_ATTACH && !bRet)
+    {
+        _initterm(__xp_a, __xp_z);
+        _initterm(__xt_a, __xt_z);
+    }
+    return bRet;
+}
+
+#else // _APPTYPE != __UNKNOWN_APP
+
+extern int    _argc;
+extern char **_argv;
+
+/* In MSVCRT.DLL, Microsoft's initialization hook is called __getmainargs(),
+ * and it expects a further structure argument, (which we don't use, but pass
+ * it as a dummy, with a declared size of zero in its first and only field).
+ */
+typedef struct _startupinfo { int mode; } _startupinfo;
+extern void __getmainargs( int *argc, char ***argv, char ***penv, int glob, _startupinfo *info );
+
+/* The function mainCRTStartup() is the entry point for all 
+ * console/desktop programs.
+ */
+#if _APPTYPE == __CONSOLE_APP
+void mainCRTStartup(void)
+#else
+void WinMainCRTStartup(void)
+#endif
+{
+    int nRet, xRet;
+    __set_app_type(_APPTYPE);
+
+    /* The MSVCRT.DLL start-up hook requires this invocation
+     * protocol...
+     */
+    char **envp = NULL;
+    _startupinfo start_info = { 0 };
+    __getmainargs(&_argc, &_argv, &envp, 0, &start_info);
+
+    _initterm(__xi_a, __xi_z);
+    _initterm(__xc_a, __xc_z);
+
+#if _APPTYPE == __CONSOLE_APP
+    nRet = main(_argc, _argv, envp);
+#else
+    {
+        STARTUPINFOA startupInfo;
+        GetStartupInfoA(&startupInfo);
+        int showWindowMode = startupInfo.dwFlags & STARTF_USESHOWWINDOW
+                           ? startupInfo.wShowWindow : SW_SHOWDEFAULT;
+        PCSTR lpszCommandLine = GetCommandLineA();
+        nRet = WinMain((HINSTANCE)&__ImageBase, NULL, lpszCommandLine, showWindowMode);
+    }
+#endif
+
+    _initterm(__xp_a, __xp_z);
+    _initterm(__xt_a, __xt_z);
+
+    if (nRet == 0)
+        nRet = xRet;
+
+    ExitProcess(nRet);
+}
+#endif // _APPTYPE != __UNKNOWN_APP


### PR DESCRIPTION
add tool to build a simple replacement for the VC runtime and the Windows SDK using the preinstalled MSVCRT.DLL and import libraries generated from MinGW definition files.

Compilation will have to be done with -mscrtlib=msvcrt51 to pick up this runtime.

To be integrated with the installer builds...