### PR TITLE
Add header & footer macros to the changed.d script

### DIFF
--- a/changed.d
+++ b/changed.d
@@ -388,6 +388,7 @@ Please supply a bugzilla version
     auto w = f.lockingTextWriter();
     w.put("Ddoc\n\n");
     w.formattedWrite("$(CHANGELOG_NAV_LAST %s)\n\n", previousVersion);
+    w.put("$(CHANGELOG_HEADER)\n");
 
     {
         // NITGHLY_VERSION is a special ddoc macro with e.g. different download links
@@ -444,12 +445,15 @@ Please supply a bugzilla version
             revRange.getBugzillaChanges.writeBugzillaChanges(w);
     }
 
+    w.put("$(CHANGELOG_FOOTER)\n");
     w.formattedWrite("$(CHANGELOG_NAV_LAST %s)\n", previousVersion);
 
     // write own macros
     w.formattedWrite(`Macros:
     VER=%s
     TITLE=Change Log: $(VER)
+    CHANGELOG_HEADER=
+    CHANGELOG_FOOTER=
 `, nextVersionString);
 
     writefln("Change log generated to: '%s'", outputFile);


### PR DESCRIPTION
Allows an easy way to inject more content into the generated changelog file.