### PR TITLE
Update .mailmap entry for Dicebot / Михаил Страшун.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -72,6 +72,8 @@ Petar Kirov <petar.p.kirov@gmail.com> <petar.p.kirov@gmail.com>
 ponce <aliloko@gmail.com> <aliloko@gmail.com>
 Михаил Страшун <public@dicebot.lv>
 Михаил Страшун <public@dicebot.lv> <m.strashun@gmail.com>
+Михаил Страшун <public@dicebot.lv> <mihails.strasuns.contractor@sociomantic.com>
+Михаил Страшун <public@dicebot.lv> <registrations@dicebot.lv>
 Rainer Schuetze <r.sagitario@gmx.de> <r.sagitario@gmx.de>
 Razvan Nitu <razvan.nitu1305@gmail.com> <razvan.nitu1305@gmail.com>
 Robert burner Schadek <robert.schadek@informatik.uni-oldenburg.de> <rburners@gmail.com>


### PR DESCRIPTION
His various email addresses are gleaned from git log. Not sure if this is all of them, but should cover the ones used in Phobos.