### PR TITLE
Expect dependencies in same directory to prevent accidental name clashes

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -1,9 +1,9 @@
-DMD_DIR = ../dmd
+DMD_DIR = dmd
 DMD = $(DMD_DIR)/generated/$(OS)/release/$(MODEL)/dmd
 CC = gcc
-INSTALL_DIR = ../install
-DRUNTIME_PATH = ../druntime
-PHOBOS_PATH = ../phobos
+INSTALL_DIR = install
+DRUNTIME_PATH = druntime
+PHOBOS_PATH = phobos
 DUB=dub
 
 WITH_DOC = no


### PR DESCRIPTION
I think that it's better to expect the dependency dirs inside the tools directory because it's the only place you can be sure of no problems with the outside world. https://github.com/dlang/tools/pull/250#discussion_r160043173

See also https://github.com/dlang/tools/pull/250#discussion_r160036252 and following comments.
