### PR TITLE
Fix bug 18079 - rdmd does not discover all dependencies

### DIFF
--- a/rdmd.d
+++ b/rdmd.d
@@ -717,7 +717,7 @@ private string[string] getDependencies(string rootModule, string workDir,
     auto depsGetter =
         // "cd " ~ shellQuote(rootDir) ~ " && "
         [ compiler ] ~ compilerFlags ~
-        ["-v", "-o-", rootModule, "-I" ~ rootDir];
+        ["-v", "-deps", "-o-", rootModule, "-I" ~ rootDir];
 
     scope(failure)
     {


### PR DESCRIPTION
Fix for issue https://issues.dlang.org/show_bug.cgi?id=18079

This will result in a known performance decrease but this is unavoidable unless we can modify `rdmd` to invoke `dmd` 1 time instead of 2.