### PR TITLE
Rework rdmd_test to support running test suite with multiple different compilers

### DIFF
--- a/rdmd_test.d
+++ b/rdmd_test.d
@@ -45,7 +45,6 @@ else
 string rdmdApp; // path/to/rdmd.exe (once built)
 string compiler = "dmd";  // e.g. dmd/gdmd/ldmd
 string model = "64"; // build architecture for dmd
-string[] rdmdArgs; // path to rdmd + common arguments (compiler, model)
 bool verbose = false;
 
 void main(string[] args)
@@ -74,11 +73,9 @@ void main(string[] args)
     enforce(res.status == 0, res.output);
     enforce(rdmdApp.exists);
 
-    rdmdArgs = [rdmdApp, compilerSwitch(compiler), modelSwitch(model)];
-
-    runTests();
+    runTests(rdmdApp, compiler, model);
     if (concurrencyTest)
-        runConcurrencyTest();
+        runConcurrencyTest(rdmdApp, compiler, model);
 
     runFallbackTest(rdmdApp, compiler, model);
 }
@@ -100,8 +97,11 @@ auto rdmdArguments(string rdmdApp, string compiler, string model)
     return [rdmdApp, compilerSwitch(compiler), modelSwitch(model)];
 }
 
-void runTests()
+void runTests(string rdmdApp, string compiler, string model)
 {
+    // path to rdmd + common arguments (compiler, model)
+    auto rdmdArgs = rdmdArguments(rdmdApp, compiler, model);
+
     /* Test help string output when no arguments passed. */
     auto res = execute([rdmdApp]);
     assert(res.status == 1, res.output);
@@ -522,8 +522,11 @@ void runTests()
     }
 }
 
-void runConcurrencyTest()
+void runConcurrencyTest(string rdmdApp, string compiler, string model)
 {
+    // path to rdmd + common arguments (compiler, model)
+    auto rdmdArgs = rdmdArguments(rdmdApp, compiler, model);
+
     string sleep100 = tempDir().buildPath("delay_.d");
     std.file.write(sleep100, "void main() { import core.thread; Thread.sleep(100.msecs); }");
     auto argsVariants =

--- a/rdmd_test.d
+++ b/rdmd_test.d
@@ -95,6 +95,11 @@ auto execute(T...)(T args)
     return std.process.execute(args);
 }
 
+auto rdmdArguments(string rdmdApp, string compiler, string model)
+{
+    return [rdmdApp, compilerSwitch(compiler), modelSwitch(model)];
+}
+
 void runTests()
 {
     /* Test help string output when no arguments passed. */

--- a/rdmd_test.d
+++ b/rdmd_test.d
@@ -69,20 +69,21 @@ void main(string[] args)
     if (compiler.canFind!isDirSeparator)
         compiler = buildNormalizedPath(compiler.absolutePath());
 
-    auto res = execute([compiler, modelSwitch, "-of" ~ rdmdApp, rdmd]);
+    auto res = execute([compiler, modelSwitch(model), "-of" ~ rdmdApp, rdmd]);
 
     enforce(res.status == 0, res.output);
     enforce(rdmdApp.exists);
 
-    rdmdArgs = [rdmdApp, compilerSwitch, modelSwitch];
+    rdmdArgs = [rdmdApp, compilerSwitch(compiler), modelSwitch(model)];
 
     runTests();
     if (concurrencyTest)
         runConcurrencyTest();
 }
 
-@property string compilerSwitch() { return "--compiler=" ~ compiler; }
-@property string modelSwitch() { return "-m" ~ model; }
+string compilerSwitch(string compiler) { return "--compiler=" ~ compiler; }
+
+string modelSwitch(string model) { return "-m" ~ model; }
 
 auto execute(T...)(T args)
 {
@@ -183,7 +184,7 @@ void runTests()
     std.file.write(subModSrc, "module dsubpack.submod; void foo() { }");
 
     // build an object file out of the dependency
-    res = execute([compiler, modelSwitch, "-c", "-of" ~ subModObj, subModSrc]);
+    res = execute([compiler, modelSwitch(model), "-c", "-of" ~ subModObj, subModSrc]);
     assert(res.status == 0, res.output);
 
     string subModUser = tempDir().buildPath("subModUser_.d");
@@ -330,7 +331,7 @@ void runTests()
     std.file.write(localDMD, "empty shell");
     scope(exit) std.file.remove(localDMD);
 
-    res = execute(rdmdApp ~ [modelSwitch, "--force", "--chatty", "--eval=writeln(`Compiler found.`);"]);
+    res = execute(rdmdApp ~ [modelSwitch(model), "--force", "--chatty", "--eval=writeln(`Compiler found.`);"]);
     assert(res.status == 1, res.output);
     assert(res.output.canFind(`spawn ["` ~ localDMD ~ `",`));
 

--- a/rdmd_test.d
+++ b/rdmd_test.d
@@ -42,15 +42,15 @@ else
     static assert(0, "Unsupported operating system.");
 }
 
-string rdmdApp; // path/to/rdmd.exe (once built)
-string compiler = "dmd";  // e.g. dmd/gdmd/ldmd
-string model = "64"; // build architecture for dmd
 bool verbose = false;
 
 void main(string[] args)
 {
+    string compiler = "dmd";  // e.g. dmd/gdmd/ldmd
     string rdmd = "rdmd.d";
     bool concurrencyTest;
+    string model = "64"; // build architecture for dmd
+
     getopt(args,
         "compiler", &compiler,
         "rdmd", &rdmd,
@@ -61,7 +61,8 @@ void main(string[] args)
 
     enforce(rdmd.exists, "Path to rdmd does not exist: %s".format(rdmd));
 
-    rdmdApp = tempDir().buildPath("rdmd_app_") ~ binExt;
+    // path/to/rdmd.exe (once built)
+    string rdmdApp = tempDir().buildPath("rdmd_app_") ~ binExt;
     if (rdmdApp.exists) std.file.remove(rdmdApp);
 
     // compiler needs to be an absolute path because we change directories

--- a/rdmd_test.d
+++ b/rdmd_test.d
@@ -46,14 +46,14 @@ bool verbose = false;
 
 void main(string[] args)
 {
-    string compiler = "dmd";  // e.g. dmd/gdmd/ldmd
+    string buildCompiler = "dmd";  // e.g. dmd/gdmd/ldmd
     string rdmd = "rdmd.d";
     bool concurrencyTest;
     string model = "64"; // build architecture for dmd
     string testCompilerList; // e.g. "ldmd2,gdmd" (comma-separated list of compiler names)
 
     getopt(args,
-        "compiler", &compiler,
+        "compiler", &buildCompiler,
         "rdmd", &rdmd,
         "concurrency", &concurrencyTest,
         "m|model", &model,
@@ -68,10 +68,10 @@ void main(string[] args)
     if (rdmdApp.exists) std.file.remove(rdmdApp);
 
     // compiler needs to be an absolute path because we change directories
-    if (compiler.canFind!isDirSeparator)
-        compiler = buildNormalizedPath(compiler.absolutePath());
+    if (buildCompiler.canFind!isDirSeparator)
+        buildCompiler = buildNormalizedPath(buildCompiler.absolutePath());
 
-    auto res = execute([compiler, modelSwitch(model), "-of" ~ rdmdApp, rdmd]);
+    auto res = execute([buildCompiler, modelSwitch(model), "-of" ~ rdmdApp, rdmd]);
 
     enforce(res.status == 0, res.output);
     enforce(rdmdApp.exists);
@@ -79,7 +79,7 @@ void main(string[] args)
     // if no explicit list of test compilers is set,
     // use the compiler used to build rdmd
     if (testCompilerList is null)
-        testCompilerList = compiler;
+        testCompilerList = buildCompiler;
 
     // run the test suite for each specified test compiler
     foreach (testCompiler; testCompilerList.split(','))
@@ -92,7 +92,7 @@ void main(string[] args)
     // run the fallback compiler test (this involves
     // searching for the build compiler, so cannot
     // be run with other test compilers)
-    runFallbackTest(rdmdApp, compiler, model);
+    runFallbackTest(rdmdApp, buildCompiler, model);
 }
 
 string compilerSwitch(string compiler) { return "--compiler=" ~ compiler; }


### PR DESCRIPTION
This patchset reworks the test-suite functions inside `rdmd_test` to allow them to be run with an arbitrary choice of `rdmd` executable, D compiler invoked by `rdmd`, and target model (32- or 64 bits).  These new features are then used to implement a new `--test-compilers` flag, which allows the user to specify a comma-separated list of different compiler names to run the test suite with.  If no test compilers are specified, the test suite will be run using the same compiler as used to build `rdmd` (the "build compiler").

This should result in identical behaviour of `rdmd_test` in cases where `--test-compilers` are not specified, but will allow CI to be updated in future to ensure that `rdmd` is tested with all the compilers that `rdmd` should support.  This should help to avoid repeats of situations like that observed in https://github.com/dlang/tools/pull/271, where breaking changes inadvertently introduced would have been spotted immediately if `rdmd` tests had been run with multiple different compilers.

No changes have been made to actual CI for now, but once this code lands it should be fairly straightforward to update makefiles and `travis.sh` to ensure that multiple different test compilers are used.

No updates have been made to `changelog.dd` since I'm not sure what reporting is expected for `rdmd_test`, but that can be updated easily if desired.

Note that the approach here could be extended still further to implement `--test-models` in future, but since testing compiler support is the focus of interest at the current moment, this is left for a later decision.

**Important:** the test on L351 of the final code currently breaks if `ldmd2` is used as a test compiler.  It's not 100% obvious what the intention is behind this test: it very explicitly _excludes_ the use of the `--compiler` flag to `rdmd`, and no attempt has been made to change this, since without a clearer sense of the intentions behind this test, it seems better to preserve the pre-existing test than to risk breaking it for the sake of a new use-case.

The original code:

```D
    res = execute(rdmdApp ~ [modelSwitch, "--force", "--chatty", "--eval=writeln(`Compiler found.`);"]);
    assert(res.status == 1, res.output);
    assert(res.output.canFind(`spawn ["` ~ localDMD ~ `",`));
```

... was apparently written by @joakim-noah: can you possibly comment on this?  (This PR tweaks the `modelSwitch` call to reflect the fact that `model` is now an input parameter to the `runTests` function, rather than a global.)

**In the bigger picture:** the design of `rdmd_test` seems a little bit odd inasmuch as it builds its own `rdmd` rather than running tests using an already-built `rdmd` instance.  It's not obvious to why this is so but it looks a little problematic (don't we want to test `rdmd` as built by the standard build scripts?).  No attempt has been made to address this for now, but it may be worth considering in future.