### PR TITLE
Modify `which` function to match Windows search behavior.

### DIFF
--- a/rdmd.d
+++ b/rdmd.d
@@ -897,9 +897,9 @@ string which(string path)
     if (path.canFind(dirSeparator) || altDirSeparator != "" && path.canFind(altDirSeparator)) return path;
     string[] extensions = [""];
     version(Windows) extensions ~= environment["PATHEXT"].split(pathSeparator);
-    foreach (extension; extensions)
+    foreach (envPath; environment["PATH"].splitter(pathSeparator))
     {
-        foreach (envPath; environment["PATH"].splitter(pathSeparator))
+        foreach (extension; extensions)
         {
             string absPath = buildPath(envPath, path ~ extension);
             yap("stat ", absPath);


### PR DESCRIPTION
Note, this doesn't affect linux, only windows.  The problem is that the inner/outer loops for searching for a program in the `which` function is in the wrong order.  You should go through each PATH, and in each one search for a program matching every extension in PATHEXT.