### PR TITLE
Use multiple different test compilers when invoking rdmd_test from Travis CI

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -8,6 +8,12 @@ DUB=dub
 
 RDMD_TEST_COMPILERS = $(abspath $(DMD))
 
+VERBOSE_RDMD_TEST=0
+
+ifeq ($(VERBOSE_RDMD_TEST), 1)
+	override VERBOSE_RDMD_TEST_FLAGS:=-v
+endif
+
 WITH_DOC = no
 DOC = ../dlang.org
 
@@ -113,7 +119,8 @@ test_tests_extractor: $(ROOT)/tests_extractor
 
 test_rdmd: $(ROOT)/rdmd_test $(ROOT)/rdmd
 	$< --compiler=$(abspath $(DMD)) -m$(MODEL) \
-	   --test-compilers=$(RDMD_TEST_COMPILERS)
+	   --test-compilers=$(RDMD_TEST_COMPILERS) \
+	   $(VERBOSE_RDMD_TEST_FLAGS)
 	$(DMD) $(DFLAGS) -unittest -main -run rdmd.d
 
 test: test_tests_extractor test_rdmd

--- a/posix.mak
+++ b/posix.mak
@@ -6,6 +6,8 @@ DRUNTIME_PATH = ../druntime
 PHOBOS_PATH = ../phobos
 DUB=dub
 
+RDMD_TEST_COMPILERS = $(abspath $(DMD))
+
 WITH_DOC = no
 DOC = ../dlang.org
 
@@ -110,7 +112,8 @@ test_tests_extractor: $(ROOT)/tests_extractor
 	$< -i ./test/tests_extractor/iteration.d | diff - ./test/tests_extractor/iteration.d.ext
 
 test_rdmd: $(ROOT)/rdmd_test $(ROOT)/rdmd
-	$< --compiler=$(abspath $(DMD)) -m$(MODEL)
+	$< --compiler=$(abspath $(DMD)) -m$(MODEL) \
+	   --test-compilers=$(RDMD_TEST_COMPILERS)
 	$(DMD) $(DFLAGS) -unittest -main -run rdmd.d
 
 test: test_tests_extractor test_rdmd

--- a/travis.sh
+++ b/travis.sh
@@ -2,5 +2,13 @@
 
 set -uexo pipefail
 
-make -f posix.mak all DMD="$(which $DMD)"
-make -f posix.mak test DMD="$(which $DMD)"
+~/dlang/install.sh install ldc
+
+~/dlang/install.sh list
+
+LDMD2=$(find ~/dlang -type f -name "ldmd2")
+
+make -f posix.mak all DMD=$(which dmd)
+make -f posix.mak test DMD=$(which dmd) \
+    RDMD_TEST_COMPILERS=dmd,$LDMD2 \
+    VERBOSE_RDMD_TEST=1


### PR DESCRIPTION
These patches introduce a simple proof-of-concept for using `rdmd_test`'s new `--test-compilers` flag in CI.  The `posix.mak` makefile has been extended with a new `RDMD_TEST_COMPILERS` variable, which can be used to set the choice of compilers to be tested with `rdmd_test`.  This is then used to update Travis CI settings to test with both `dmd` and `ldmd2` (with the latter being installed as a distro package).  `gdmd` is not included for the time being since installing it would have been trickier (there is a `gdc` distro package available but it does not include the `gdmd` perl script).

The last patch is added just for testing purposes and should probably be dropped before this PR is accepted: it makes the `test_rdmd` make target run `rdmd_test` verbosely so that we can clearly see the multiple compilers in action.

This should probably not be the final form for setting up multi-compiler tests of `rdmd`, but it serves as an initial stage which should at a minimum flag up issues like that observed with https://github.com/dlang/tools/pull/271.

No changes have been made to windows makefiles, since this is not required by Travis CI.  I would anticipate this being fairy easy to add if desired, but it might be a good idea if this was done by someone with more Windows experience in a separate PR.