### PR TITLE
Remove digger setup and use the compiler from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: d
-d:
-  - dmd
 sudo: false
 
 matrix:
   include:
-    - env: MODEL=64
-    - env: MODEL=32
+    - d: dmd
+      env: MODEL=64
+    - d: dmd-nightly
+      env: MODEL=64
+    - d: dmd
+      env: MODEL=32
       addons:
         apt:
           packages:

--- a/travis.sh
+++ b/travis.sh
@@ -2,34 +2,5 @@
 
 set -uexo pipefail
 
-DIGGER_DIR="../digger"
-DIGGER="../digger/digger"
-
-# set to 64-bit by default
-if [ -z ${MODEL:-} ] ; then
-    MODEL=64
-fi
-
-build_digger() {
-    git clone --recursive https://github.com/CyberShadow/Digger "$DIGGER_DIR"
-    git -C "$DIGGER_DIR" checkout v3.0.0-alpha-5
-    (cd "$DIGGER_DIR" && rdmd --build-only -debug digger)
-}
-
-install_digger() {
-    $DIGGER build --model=$MODEL "master"
-    export PATH=$PWD/work/result/bin:$PATH
-}
-
-if ! [ -d "$DIGGER_DIR" ] ; then
-    build_digger
-fi
-
-install_digger
-
-dmd --version
-rdmd --help | head -n 1
-dub --version
-
-make -f posix.mak all DMD=$(which dmd)
-make -f posix.mak test DMD=$(which dmd)
+make -f posix.mak all DMD="$(which $DMD)"
+make -f posix.mak test DMD="$(which $DMD)"


### PR DESCRIPTION
Digger was added to be able to test `tools` with the latest DMD.
So Digger builds the latest `dmd`, `druntime` and `phobos` and we have enabled a daily cron here that checks every day that things are still working.
However, now that we have the Project Tester we can simply add `dlang/tools` to it and thus be on the safe side as the testsuite is now run on every PR.

The respective dlang/ci PR is: https://github.com/dlang/ci/pull/130