### PR TITLE
Bump libdparse to 0.7.2-alpha.6

### DIFF
--- a/tests_extractor.d
+++ b/tests_extractor.d
@@ -1,7 +1,7 @@
 #!/usr/bin/env dub
 /++dub.sdl:
 name "tests_extractor"
-dependency "libdparse" version="~>0.7.2-alpha.4"
+dependency "libdparse" version="~>0.7.2-alpha.6"
 +/
 /*
  * Parses all public unittests that are visible on dlang.org


### PR DESCRIPTION
Required to "unbreak" CircleCi at Phobos.
Depends on https://github.com/dlang-community/libdparse/pull/188