### PR TITLE
Issue 18351 - integrate dub changelog with changed.d tool

### DIFF
--- a/changed.d
+++ b/changed.d
@@ -152,6 +152,7 @@ auto getBugzillaChanges(string revRange)
             case "installer": comp = "Installer"; break;
             case "phobos": comp = "Phobos"; break;
             case "tools": comp = "Tools"; break;
+            case "dub": comp = "Dub"; break;
             case "visuald": comp = "VisualD"; break;
             default: assert(0, comp);
         }
@@ -405,7 +406,8 @@ Please supply a bugzilla version
                           Repo("phobos", "Library changes"),
                           Repo("dlang.org", "Language changes"),
                           Repo("installer", "Installer changes"),
-                          Repo("tools", "Tools changes")];
+                          Repo("tools", "Tools changes"),
+                          Repo("dub", "Dub changes")];
 
             auto changedRepos = repos
                  .map!(repo => Repo(buildPath("..", repo.path, repo.path == "dlang.org" ? "language-changelog" : "changelog"), repo.headline))


### PR DESCRIPTION
First step of integrating dub's changelog with the DMD release annoucement.
This will at least allow for manual changelog entries to be part of the release.

It can't query issues at the moment because
- a different tagging version system is used
- DUB doesn't have a Bugzilla issue tracker (and we haven't integrated GH issues so far)

See also: https://github.com/dlang/dlang.org/pull/2163