### PR TITLE
Add 32-bit dmd-nightly builds to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,13 @@ matrix:
           packages:
             - g++-multilib
             - libcurl4-openssl-dev:i386
+    - d: dmd-nightly
+      env: MODEL=32
+      addons:
+        apt:
+          packages:
+            - g++-multilib
+            - libcurl4-openssl-dev:i386
 
 script:
   - ./travis.sh


### PR DESCRIPTION
For some reason 32-bit builds are only tested for stable `dmd`.  This seems an oversight: we don't want to find out that the D tools break 32-bit `dmd` only after a stable release has come out!

This patch therefore adds an extra Travis build with `DMD=dmd-nightly` and `MODEL=32`.