### PR TITLE
Quote variables in travis.sh to prevent word splitting

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -8,7 +8,7 @@ set -uexo pipefail
 
 LDMD2=$(find ~/dlang -type f -name "ldmd2")
 
-make -f posix.mak all DMD=$(which dmd)
-make -f posix.mak test DMD=$(which dmd) \
-    RDMD_TEST_COMPILERS=dmd,$LDMD2 \
+make -f posix.mak all DMD="$(which dmd)"
+make -f posix.mak test DMD="$(which dmd)" \
+    RDMD_TEST_COMPILERS=dmd,"$LDMD2" \
     VERBOSE_RDMD_TEST=1


### PR DESCRIPTION
This is probably unnecessary for the use-case but can never hurt, so let's follow shellcheck's nice and helpful hints ;-)

@wilzbach thanks for the introduction to the nice tool, it's one I didn't know before.