### PR TITLE
Change !isDir to isFile

### DIFF
--- a/rdmd.d
+++ b/rdmd.d
@@ -465,7 +465,7 @@ private int rebuild(string root, string fullExe,
     yap("stat ", fullExe);
     if (exists(fullExe))
     {
-        enforce(!isDir(fullExe), fullExe ~ " is a directory");
+        enforce(isFile(fullExe), fullExe ~ " is not a regular file");
         yap("rm ", fullExe);
         if (!dryRun)
         {


### PR DESCRIPTION
File types are split into more than just directories and files.  In this case, `fullExe` must be a regular file, so checking `isFile` removes any question about whether or not it is actually a file.  The current implementation uses `!isDir` which could still be true even if `fullExe` is not a regular file, which is not the logic we want here.