### PR TITLE
Add gdc/gdmd to compilers tested by Travis with rdmd_test

### DIFF
--- a/rdmd_test.d
+++ b/rdmd_test.d
@@ -487,8 +487,11 @@ void runTests(string rdmdApp, string compiler, string model)
     }
 
     /* [REG2.072.0] pragma(lib) is broken with rdmd: https://issues.dlang.org/show_bug.cgi?id=16978 */
+    /* GDC does not support `pragma(lib)`, so disable when test compiler is gdmd: https://issues.dlang.org/show_bug.cgi?id=18421
+       (this constraint can be removed once GDC support for `pragma(lib)` is implemented) */
 
     version (linux)
+    if (compiler.baseName != "gdmd")
     {{
         TmpDir srcDir = "rdmdTest";
         string libSrcName = srcDir.buildPath("libfun.d");

--- a/travis.sh
+++ b/travis.sh
@@ -2,13 +2,15 @@
 
 set -uexo pipefail
 
+~/dlang/install.sh install gdc
 ~/dlang/install.sh install ldc
 
 ~/dlang/install.sh list
 
+GDMD=$(find ~/dlang -type f -name "gdmd")
 LDMD2=$(find ~/dlang -type f -name "ldmd2")
 
 make -f posix.mak all DMD="$(which dmd)"
 make -f posix.mak test DMD="$(which dmd)" \
-    RDMD_TEST_COMPILERS=dmd,"$LDMD2" \
+    RDMD_TEST_COMPILERS=dmd,"$GDMD","$LDMD2" \
     VERBOSE_RDMD_TEST=1


### PR DESCRIPTION
This patch updates travis.sh to install GDC and to include the DMD-alike `gdmd` compiler frontend among the `RDMD_TEST_COMPILERS`.

Since GDC does not yet implement `pragma(lib)`, the `rdmd_test` case for this has been disabled for the case where `gdmd` is the test compiler.