### PR TITLE
ddemangle: add option to add underscore (useful for OSX where lldb removes underscore)

### DIFF
--- a/ddemangle.d
+++ b/ddemangle.d
@@ -40,8 +40,7 @@ enum suffix = r"[0-9a-zA-Z_]+\b";
 auto reDemangle = regex(r"\b(_?_D|_Z)" ~ suffix);
 auto reDemangleUnderscoreMissing = regex(r"\b(D|_Z)" ~ suffix);
 
-const(char)[] demangleMatch(T)(Captures!(T) m)
-if (is(T : const(char)[]))
+const(char)[] demangleMatch(T)(Captures!(T) m) if (is(T : const(char)[]))
 {
     /+ If the second character is an underscore, it may be a D symbol with double leading underscore;
      + in that case, try to demangle it with only one leading underscore.

--- a/ddemangle.d
+++ b/ddemangle.d
@@ -131,7 +131,6 @@ unittest
     assert(equal(testData2.map!(a=>a.ddemangle(true)), expected2));
 }
 
-version(none)
 void main(string[] args)
 {
     bool underscore_missing = false;

--- a/ddemangle.d
+++ b/ddemangle.d
@@ -83,7 +83,8 @@ const(char)[] demangleMatchUnderscoreMissing(T)(Captures!(T) m)
     }
 }
 
-auto ddemangle(T)(T line, UnderscoreMissing underscoreMissing) if (is(T : const(char)[]))
+auto ddemangle(T)(T line, UnderscoreMissing underscoreMissing)
+        if (is(T : const(char)[]))
 {
     if (underscoreMissing)
         return replaceAll!demangleMatch(line, reDemangleUnderscoreMissing);
@@ -140,9 +141,12 @@ void main(string[] args)
     // Parse command-line arguments
     try
     {
-        getopt(args, "help|h", { showhelp(args); }, "underscoreMissing|u", {
-            underscoreMissing = Yes.underscoreMissing;
-        },);
+        // dfmt off
+        getopt(args,
+            "help|h", { showhelp(args); },
+            "underscoreMissing|u", { underscoreMissing = Yes.underscoreMissing; },
+        );
+        // dfmt on
         if (args.length > 2)
             showhelp(args);
     }

--- a/ddemangle.d
+++ b/ddemangle.d
@@ -39,7 +39,8 @@ enum suffix = r"D[0-9a-zA-Z_]+\b";
 auto reDemangle = regex(r"\b_?_" ~ suffix);
 auto reDemangleUnderscoreMissing = regex(r"\b" ~ suffix);
 
-const(char)[] demangleMatch(T)(Captures!(T) m) if (is(T : const(char)[]))
+const(char)[] demangleMatch(T)(Captures!(T) m)
+if (is(T : const(char)[]))
 {
     /+ If the second character is an underscore, it may be a D symbol with double leading underscore;
      + in that case, try to demangle it with only one leading underscore.
@@ -64,7 +65,7 @@ const(char)[] demangleMatch(T)(Captures!(T) m) if (is(T : const(char)[]))
 }
 
 const(char)[] demangleMatchUnderscoreMissing(T)(Captures!(T) m)
-        if (is(T : const(char)[]))
+if (is(T : const(char)[]))
 {
     static Appender!string ret;
     ret.ret;
@@ -84,7 +85,7 @@ const(char)[] demangleMatchUnderscoreMissing(T)(Captures!(T) m)
 }
 
 auto ddemangle(T)(T line, UnderscoreMissing underscoreMissing)
-        if (is(T : const(char)[]))
+if (is(T : const(char)[]))
 {
     if (underscoreMissing)
         return replaceAll!demangleMatch(line, reDemangleUnderscoreMissing);

--- a/ddemangle.d
+++ b/ddemangle.d
@@ -109,9 +109,29 @@ unittest
         "fail demangling __D6object9Throwable8toStringMFZAy"
     ];
 
-    assert(equal(testData.map!ddemangle(), expected));
+    assert(equal(testData.map!(a=>a.ddemangle(false)), expected));
+
+    string[] testData2 = [
+        "D2rt4util7console8__assertFiZv",
+        "random initial junk D2rt4util7console8__assertFiZv random trailer",
+        "multiple D2rt4util7console8__assertFiZv occurrences D2rt4util7console8__assertFiZv",
+        "D6object9Throwable8toStringMFZAya",
+        "don't match 1 leading underscores _D6object9Throwable8toStringMFZAya",
+        "fail demangling D6object9Throwable8toStringMFZAy"
+    ];
+    string[] expected2 = [
+        "void rt.util.console.__assert(int)",
+        "random initial junk void rt.util.console.__assert(int) random trailer",
+        "multiple void rt.util.console.__assert(int) occurrences void rt.util.console.__assert(int)",
+        "immutable(char)[] object.Throwable.toString()",
+        "don't match 1 leading underscores _D6object9Throwable8toStringMFZAya",
+        "fail demangling D6object9Throwable8toStringMFZAy"
+    ];
+
+    assert(equal(testData2.map!(a=>a.ddemangle(true)), expected2));
 }
 
+version(none)
 void main(string[] args)
 {
     bool underscore_missing = false;

--- a/ddemangle.d
+++ b/ddemangle.d
@@ -109,7 +109,7 @@ unittest
         "fail demangling __D6object9Throwable8toStringMFZAy"
     ];
 
-    assert(equal(testData.map!(a=>a.ddemangle(false)), expected));
+    assert(equal(testData.map!(a => a.ddemangle(false)), expected));
 
     string[] testData2 = [
         "D2rt4util7console8__assertFiZv",
@@ -128,7 +128,7 @@ unittest
         "fail demangling D6object9Throwable8toStringMFZAy"
     ];
 
-    assert(equal(testData2.map!(a=>a.ddemangle(true)), expected2));
+    assert(equal(testData2.map!(a => a.ddemangle(true)), expected2));
 }
 
 void main(string[] args)

--- a/ddemangle.d
+++ b/ddemangle.d
@@ -33,11 +33,10 @@ ENDHELP", args[0]);
 }
 
 enum suffix = r"D[0-9a-zA-Z_]+\b";
-auto reDemangle = regex(r"\b_?_"~suffix);
-auto reDemangle_underscore_missing = regex(r"\b"~suffix);
+auto reDemangle = regex(r"\b_?_" ~ suffix);
+auto reDemangle_underscore_missing = regex(r"\b" ~ suffix);
 
-const(char)[] demangleMatch(T)(Captures!(T) m)
-    if (is(T : const(char)[]))
+const(char)[] demangleMatch(T)(Captures!(T) m) if (is(T : const(char)[]))
 {
     /+ If the second character is an underscore, it may be a D symbol with double leading underscore;
      + in that case, try to demangle it with only one leading underscore.
@@ -48,8 +47,8 @@ const(char)[] demangleMatch(T)(Captures!(T) m)
     }
     else
     {
-        auto result = demangle(m.hit[1..$]);
-        if (result == m.hit[1..$])
+        auto result = demangle(m.hit[1 .. $]);
+        if (result == m.hit[1 .. $])
         {
             // Demangling failed, return original match with (!) double underscore
             return m.hit;
@@ -62,13 +61,13 @@ const(char)[] demangleMatch(T)(Captures!(T) m)
 }
 
 const(char)[] demangleMatchUnderscoreMissing(T)(Captures!(T) m)
-    if (is(T : const(char)[]))
-{   
+        if (is(T : const(char)[]))
+{
     static Appender!string ret;
     ret.ret;
-    ret~="_";
-    ret~=m.hit;
-    auto line2=ret.data;
+    ret ~= "_";
+    ret ~= m.hit;
+    auto line2 = ret.data;
     auto result = demangle(line2);
     if (result == line2)
     {
@@ -81,10 +80,9 @@ const(char)[] demangleMatchUnderscoreMissing(T)(Captures!(T) m)
     }
 }
 
-auto ddemangle(T)(T line, bool underscore_missing)
-    if (is(T : const(char)[]))
+auto ddemangle(T)(T line, bool underscore_missing) if (is(T : const(char)[]))
 {
-    if(underscore_missing)
+    if (underscore_missing)
         return replaceAll!demangleMatch(line, reDemangle_underscore_missing);
     else
         return replaceAll!demangleMatch(line, reDemangle);
@@ -116,17 +114,17 @@ unittest
 
 void main(string[] args)
 {
-    bool underscore_missing=false;
+    bool underscore_missing = false;
     // Parse command-line arguments
     try
     {
-        getopt(args,
-            "help|h", { showhelp(args); },
-            "underscore_missing|u", { underscore_missing = true; },
-        );
-        if (args.length > 2) showhelp(args);
+        getopt(args, "help|h", { showhelp(args); }, "underscore_missing|u", {
+            underscore_missing = true;
+        },);
+        if (args.length > 2)
+            showhelp(args);
     }
-    catch(Exception e)
+    catch (Exception e)
     {
         stderr.writeln(e.msg);
         stderr.writeln();
@@ -136,14 +134,14 @@ void main(string[] args)
     // Process input
     try
     {
-        auto f = (args.length==2) ? File(args[1], "r") : stdin;
+        auto f = (args.length == 2) ? File(args[1], "r") : stdin;
         foreach (line; f.byLine())
         {
             writeln(ddemangle(line, underscore_missing));
             stdout.flush;
         }
     }
-    catch(Exception e)
+    catch (Exception e)
     {
         stderr.writeln(e.msg);
         exit(1);


### PR DESCRIPTION
cc @CyberShadow if you have any comments

similar to `c++filt -n` option

eg w lldb on OSX:
bt:
```
frame #32: 0x0000000100001677 dmd _Dmain + 39 at dmd/src/dmd/mars.d:1052
    frame #33: 0x000000010027ec24 dmd D2rt6dmain211_d_run_mainUiPPaPUAAaZiZ6runAllMFZ9__lambda1MFZv + 40
    frame #34: 0x000000010027eab4 dmd D2rt6dmain211_d_run_mainUiPPaPUAAaZiZ7tryExecMFMDFZvZv + 32
    frame #35: 0x000000010027eb8f dmd D2rt6dmain211_d_run_mainUiPPaPUAAaZiZ6runAllMFZv + 139
    frame #36: 0x000000010027eab4 dmd D2rt6dmain211_d_run_mainUiPPaPUAAaZiZ7tryExecMFMDFZvZv + 32
    frame #37: 0x000000010027ea22 dmd _d_run_main + 486
```

NOTE: this is useful even if after dlang/dmd#7620 gets merged, as we still want ddemangle to work on stacktraces produced by compilers that don't have that fix.

NOTE: interestingly, core.demangle seems to accept symbols with 0 leading underscore, eg D2rt4util7console8__assertFiZv ; this simplifies case with missing underscore.

NOTE: also, made the regex that triggers demangle support _Z for C++ symbols, so it'll work with  https://github.com/dlang/druntime/pull/2083
