### PR TITLE
Improve codeblock detection

### DIFF
--- a/changed.d
+++ b/changed.d
@@ -280,7 +280,7 @@ void writeTextChangesBody(Entries, Writer)(Entries changes, Writer w, string hea
         bool inPara, inCode;
         foreach (line; change.description.splitLines)
         {
-            if (line.startsWith("---"))
+            if (line.stripLeft.startsWith("---"))
             {
                 if (inPara)
                 {


### PR DESCRIPTION
This allows the following DDoc style in the changelog entries:

```
    ---
    int result;
    ---
```

This is needed to fix the nightly changelog: http://dlang.org/changelog/pending.html

As the branch-off is about to happen soon a fast merge would be appreciated. Thanks!

Before:

![image](https://user-images.githubusercontent.com/4370550/36005417-f094c464-0d37-11e8-9aba-ddd22a9abf3e.png)

After:

![image](https://user-images.githubusercontent.com/4370550/36005451-20d4883a-0d38-11e8-9461-537cb41bef90.png)

CC @CyberShadow