### PR TITLE
Emit new CHANGELOG_SOURCE_FILE DDoc macro

### DIFF
--- a/changed.d
+++ b/changed.d
@@ -353,16 +353,12 @@ int main(string[] args)
     bool hideTextChanges = false;
     string revRange;
 
-    // TODO: no-op - remove me as soon as dlang.org is upgraded
-    bool useNightlyTemplate;
-
     auto helpInformation = getopt(
         args,
         std.getopt.config.passThrough,
         "output|o", &outputFile,
         "date", &nextVersionDate,
         "version", &nextVersionString,
-        "nightly", &useNightlyTemplate,
         "prev-version", &previousVersion, // this can automatically be detected
         "no-text", &hideTextChanges);
 


### PR DESCRIPTION
Follow-up to https://github.com/dlang/dlang.org/pull/2184

Pretty stupidly simple for now:

![image](https://user-images.githubusercontent.com/4370550/36069057-a7610b2a-0ee2-11e8-8b39-fc1c03969763.png)

Requires the Ddoc macros first to prevent DAutoTest from failing - see https://github.com/dlang/dlang.org/pull/2203