### PR TITLE
checkwhitespace.d: Allow individual errors to be turned off.

### DIFF
--- a/checkwhitespace.d
+++ b/checkwhitespace.d
@@ -15,6 +15,13 @@ import std.path;
 
 int main(string[] args)
 {
+    import std.getopt;
+    bool allowdos, allowtabs, allowtrailing;
+    getopt(args,
+           "allow-windows-newlines", &allowdos,
+           "allow-tabs", &allowtabs,
+           "allow-trailing-whitespace", &allowtrailing);
+
     bool error;
     auto r = regex(r" +\n");
     foreach(a; args[1..$])
@@ -23,18 +30,18 @@ int main(string[] args)
         {
             ptrdiff_t pos;
             auto str = a.readText();
-            if ((pos = str.indexOf("\r\n")) >= 0)
+            if (!allowdos && (pos = str.indexOf("\r\n")) >= 0)
             {
                 writefln("Error - file '%s' contains windows line endings at line %d", a, str[0..pos].count('\n') + 1);
                 error = true;
             }
-            if (a.extension() != ".mak" && (pos = str.indexOf('\t')) >= 0)
+            if (!allowtabs && a.extension() != ".mak" && (pos = str.indexOf('\t')) >= 0)
             {
                 writefln("Error - file '%s' contains tabs at line %d", a, str[0..pos].count('\n') + 1);
                 error = true;
             }
             auto m = str.matchFirst(r);
-            if (!m.empty)
+            if (!allowtrailing && !m.empty)
             {
                 pos = m.front.ptr - str.ptr; // assume the match is a slice of the string
                 writefln("Error - file '%s' contains trailing whitespace at line %d", a, str[0..pos].count('\n') + 1);


### PR DESCRIPTION
To allow running checkwhitespace on files not recognized by the program, e.g:
```
checkwhitespace --allow-tabs Makefile
```

As for the option itself: `--allow-xxx`, `--disable-xxx`, `--nocheck-xxx`, I don't really mind what it's called.