### PR TITLE
rdmd_test: rewrite to use externally-specifed rdmd executable 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,3 +64,4 @@ test_script:
  - echo %PATH%
  - '%DC% --version'
  - make -f win32.mak rdmd dustmite ddemangle changed
+ - make -f win32.mak test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,11 @@ environment:
   - DC: dmd
     DVersion: nightly
     arch: x64
+    MODEL: 64
   - DC: dmd
     DVersion: nightly
     arch: x86
+    MODEL: 32
 skip_tags: false
 build_script:
  - ps: >

--- a/posix.mak
+++ b/posix.mak
@@ -111,14 +111,17 @@ test_tests_extractor: $(ROOT)/tests_extractor
 	$< -i ./test/tests_extractor/iteration.d | diff - ./test/tests_extractor/iteration.d.ext
 
 RDMD_TEST_COMPILERS = $(abspath $(DMD))
+RDMD_TEST_EXECUTABLE = $(ROOT)/rdmd
+RDMD_TEST_DEFAULT_COMPILER = $(basename $(DMD))
 
 VERBOSE_RDMD_TEST=0
 ifeq ($(VERBOSE_RDMD_TEST), 1)
 	override VERBOSE_RDMD_TEST_FLAGS:=-v
 endif
 
-test_rdmd: $(ROOT)/rdmd_test $(ROOT)/rdmd
-	$< --compiler=$(abspath $(DMD)) -m$(MODEL) \
+test_rdmd: $(ROOT)/rdmd_test $(RDMD_TEST_EXECUTABLE)
+	$< --rdmd=$(RDMD_TEST_EXECUTABLE) -m$(MODEL) \
+	   --rdmd-default-compiler=$(RDMD_TEST_DEFAULT_COMPILER) \
 	   --test-compilers=$(RDMD_TEST_COMPILERS) \
 	   $(VERBOSE_RDMD_TEST_FLAGS)
 	$(DMD) $(DFLAGS) -unittest -main -run rdmd.d

--- a/posix.mak
+++ b/posix.mak
@@ -7,14 +7,6 @@ DRUNTIME_PATH = ../druntime
 PHOBOS_PATH = ../phobos
 DUB=dub
 
-RDMD_TEST_COMPILERS = $(abspath $(DMD))
-
-VERBOSE_RDMD_TEST=0
-
-ifeq ($(VERBOSE_RDMD_TEST), 1)
-	override VERBOSE_RDMD_TEST_FLAGS:=-v
-endif
-
 WITH_DOC = no
 DOC = ../dlang.org
 
@@ -117,6 +109,13 @@ $(ROOT)/tests_extractor: tests_extractor.d
 test_tests_extractor: $(ROOT)/tests_extractor
 	$< -i ./test/tests_extractor/ascii.d | diff - ./test/tests_extractor/ascii.d.ext
 	$< -i ./test/tests_extractor/iteration.d | diff - ./test/tests_extractor/iteration.d.ext
+
+RDMD_TEST_COMPILERS = $(abspath $(DMD))
+
+VERBOSE_RDMD_TEST=0
+ifeq ($(VERBOSE_RDMD_TEST), 1)
+	override VERBOSE_RDMD_TEST_FLAGS:=-v
+endif
 
 test_rdmd: $(ROOT)/rdmd_test $(ROOT)/rdmd
 	$< --compiler=$(abspath $(DMD)) -m$(MODEL) \

--- a/rdmd_test.d
+++ b/rdmd_test.d
@@ -65,7 +65,7 @@ void main(string[] args)
 
     // path/to/rdmd.exe (once built)
     string rdmdApp = tempDir().buildPath("rdmd_app_") ~ binExt;
-    if (rdmdApp.exists) std.file.remove(rdmdApp);
+    scope (exit) std.file.remove(rdmdApp);
 
     // compiler needs to be an absolute path because we change directories
     if (buildCompiler.canFind!isDirSeparator)

--- a/win32.mak
+++ b/win32.mak
@@ -86,3 +86,21 @@ zip: detab tolf $(MAKEFILES)
 
 scp: detab tolf $(MAKEFILES)
 	$(SCP) $(SRCS) $(MAKEFILES) $(SCPDIR)
+
+
+################################################################################
+# Build and run tests
+################################################################################
+
+RDMD_TEST_COMPILERS = $(DMD)
+RDMD_TEST_EXECUTABLE = $(ROOT)\rdmd.exe
+RDMD_TEST_DEFAULT_COMPILER = $(DMD)
+
+$(ROOT)\rdmd_test.exe : rdmd_test.d
+	$(DMD) $(DFLAGS) -of$@ rdmd_test.d
+
+test_rdmd : $(ROOT)\rdmd_test.exe $(RDMD_TEST_EXECUTABLE)
+        $(ROOT)\rdmd_test.exe \
+           --rdmd=$(RDMD_TEST_EXECUTABLE) -m32 -v \
+           --rdmd-default-compiler=$(RDMD_TEST_DEFAULT_COMPILER) \
+           --test-compilers=$(RDMD_TEST_COMPILERS)

--- a/win32.mak
+++ b/win32.mak
@@ -101,7 +101,7 @@ $(ROOT)\rdmd_test.exe : rdmd_test.d
 
 test_rdmd : $(ROOT)\rdmd_test.exe $(RDMD_TEST_EXECUTABLE)
         $(ROOT)\rdmd_test.exe \
-           --rdmd=$(RDMD_TEST_EXECUTABLE) -m32 -v \
+           --rdmd=$(RDMD_TEST_EXECUTABLE) -m$(MODEL) -v \
            --rdmd-default-compiler=$(RDMD_TEST_DEFAULT_COMPILER) \
            --test-compilers=$(RDMD_TEST_COMPILERS)
 

--- a/win32.mak
+++ b/win32.mak
@@ -104,3 +104,5 @@ test_rdmd : $(ROOT)\rdmd_test.exe $(RDMD_TEST_EXECUTABLE)
            --rdmd=$(RDMD_TEST_EXECUTABLE) -m32 -v \
            --rdmd-default-compiler=$(RDMD_TEST_DEFAULT_COMPILER) \
            --test-compilers=$(RDMD_TEST_COMPILERS)
+
+test : test_rdmd


### PR DESCRIPTION
One key problem of the old `rdmd_test` was that it built its own rdmd instance to test.  This meant that technically, it was never actually run against the rdmd executable generated in the regular tools build.

This rewrite fixes this by repurposing the `--rdmd` flag of `rdmd_test` to require not a path to `rdmd.d` but a path to the rdmd executable for which the test suite should be run.  The provided executable is not used directly, but is copied into a temporary directory: this is necessary in order to run the fallback test, which involves copying a dummy compiler into the same directory as the tested rdmd executable.

The `--compiler` flag has been removed (since `rdmd_test` no longer uses it to build an rdmd executable), but a new `--fallback-compiler` flag is now required in order to specify the name of the compiler to use in the fallback test.  Note that this test will fail if the provided name does not match the name of the default compiler used by the provided rdmd.

The `test_rdmd` target in `posix.mak` has been reworked to use the new `--rdmd` and `--fallback-compiler` flags, whose values can be specified with the `RDMD_TEST_EXECUTABLE` and `RDMD_TEST_FALLBACK_COMPILER` make variables respectively.  By default, these will be set to the generated `rdmd` instance and the compiler used to build it.

This should ensure that the rdmd instance generated by the regular build is properly tested, while allowing `rdmd_test` to be used with arbitrary `rdmd` instances if any developer should wish to do so.

The first and last patches perform a bit of cleanup useful for the main changes.

Note that an assumption made by this PR is that breaking changes to `rdmd_test` are not a concern, since this is a test suite rather than a utility intended for distribution.