### PR TITLE
Simplify interface to rdmd_test and make it more robust

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -110,9 +110,8 @@ test_tests_extractor: $(ROOT)/tests_extractor
 	$< -i ./test/tests_extractor/ascii.d | diff - ./test/tests_extractor/ascii.d.ext
 	$< -i ./test/tests_extractor/iteration.d | diff - ./test/tests_extractor/iteration.d.ext
 
-RDMD_TEST_COMPILERS = $(abspath $(DMD))
+RDMD_TEST_COMPILERS = $(DMD)
 RDMD_TEST_EXECUTABLE = $(ROOT)/rdmd
-RDMD_TEST_DEFAULT_COMPILER = $(basename $(DMD))
 
 VERBOSE_RDMD_TEST=0
 ifeq ($(VERBOSE_RDMD_TEST), 1)
@@ -120,9 +119,8 @@ ifeq ($(VERBOSE_RDMD_TEST), 1)
 endif
 
 test_rdmd: $(ROOT)/rdmd_test $(RDMD_TEST_EXECUTABLE)
-	$< --rdmd=$(RDMD_TEST_EXECUTABLE) -m$(MODEL) \
-	   --rdmd-default-compiler=$(RDMD_TEST_DEFAULT_COMPILER) \
-	   --test-compilers=$(RDMD_TEST_COMPILERS) \
+	$< $(RDMD_TEST_EXECUTABLE) -m$(MODEL) \
+	   --compilers=$(RDMD_TEST_COMPILERS) \
 	   $(VERBOSE_RDMD_TEST_FLAGS)
 	$(DMD) $(DFLAGS) -unittest -main -run rdmd.d
 

--- a/win32.mak
+++ b/win32.mak
@@ -94,15 +94,13 @@ scp: detab tolf $(MAKEFILES)
 
 RDMD_TEST_COMPILERS = $(DMD)
 RDMD_TEST_EXECUTABLE = $(ROOT)\rdmd.exe
-RDMD_TEST_DEFAULT_COMPILER = $(DMD)
 
 $(ROOT)\rdmd_test.exe : rdmd_test.d
 	$(DMD) $(DFLAGS) -of$@ rdmd_test.d
 
 test_rdmd : $(ROOT)\rdmd_test.exe $(RDMD_TEST_EXECUTABLE)
         $(ROOT)\rdmd_test.exe \
-           --rdmd=$(RDMD_TEST_EXECUTABLE) -m$(MODEL) -v \
-           --rdmd-default-compiler=$(RDMD_TEST_DEFAULT_COMPILER) \
-           --test-compilers=$(RDMD_TEST_COMPILERS)
+           $(RDMD_TEST_EXECUTABLE) -m$(MODEL) -v \
+           --compilers=$(RDMD_TEST_COMPILERS)
 
 test : test_rdmd


### PR DESCRIPTION
1. Support compilers with relative filenames
2. Remove the `--rdmd-default-compiler` argument since this can be pulled from rdmd help text.
   This removes the need to specify this as an argument and is more DRY since this information is already known to the `rdmd` binary under test.
3. Since `--rdmd` is required, made it a "non-option" argument instead of an "option that is [REQUIRED]"
4. Change `--test-compilers` to `--compilers` and made it optional by defaulting to 'dmd'
5. Move non-compiler specific tests to a separate function so they only get tested once instead of once per compiler.