### PR TITLE
posix.mak, win32.mak: Ensure `clean` target removes all generated files and directories

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -15,8 +15,8 @@ $(shell [ ! -d $(DMD_DIR) ] && git clone --depth=1 https://github.com/dlang/dmd 
 include $(DMD_DIR)/src/osmodel.mak
 
 # Build folder for all binaries
-ROOT_OF_THEM_ALL = generated
-ROOT = $(ROOT_OF_THEM_ALL)/$(OS)/$(MODEL)
+GENERATED = generated
+ROOT = $(GENERATED)/$(OS)/$(MODEL)
 
 # Set DRUNTIME name and full path
 ifeq (,$(findstring win,$(OS)))
@@ -94,7 +94,7 @@ install: $(TOOLS) $(CURL_TOOLS) $(ROOT)/dustmite
 	cp $^ $(INSTALL_DIR)/bin
 
 clean:
-	rm -f $(ROOT)/dustmite $(TOOLS) $(CURL_TOOLS) $(DOC_TOOLS) $(TAGS) *.o $(ROOT)/*.o
+	rm -r $(GENERATED)
 
 $(ROOT)/tests_extractor: tests_extractor.d
 	mkdir -p $(ROOT)

--- a/win32.mak
+++ b/win32.mak
@@ -30,8 +30,8 @@ SCP=$(CP)
 
 DFLAGS=-O -release
 
-ROOT_OF_THEM_ALL = generated
-ROOT = $(ROOT_OF_THEM_ALL)\windows\32
+GENERATED = generated
+ROOT = $(GENERATED)\windows\32
 
 TARGETS=	$(ROOT)\dman.exe \
 	$(ROOT)\rdmd.exe \
@@ -72,7 +72,7 @@ $(ROOT)\changed.exe : changed.d
 	$(DMD) $(DFLAGS) -of$@ changed.d
 
 clean :
-	del $(TARGETS) $(TAGS)
+	rmdir /s /q $(GENERATED)
 
 detab:
 	$(DETAB) $(SRCS)


### PR DESCRIPTION
These patches correct some oversights in the `clean` targets declared by the makefiles.  These should ensure that all generated files are removed, not just the application binaries.

Note that this would automatically be dealt with if `clean` just removed the `$(ROOT_OF_THEM_ALL)` directory.  This option has been avoided so as to avoid changing the existing `clean` behaviour, since presumably there is some perceived risk associated with removing directories recursively.  However, it may be worth returning to this decision in future as (if it could be done safely) it would greatly simplify declaration and maintenance of the `clean` target.

**Warning:** as a non-Windows dev I have not tested the patch to `win32.mak`, so someone may want to try this out in anger before accepting the PR ;-)