### PR TITLE
Since --rdmd is required, made it a "non-option" argument instead of an "option that is [REQUIRED]"

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -120,7 +120,7 @@ ifeq ($(VERBOSE_RDMD_TEST), 1)
 endif
 
 test_rdmd: $(ROOT)/rdmd_test $(RDMD_TEST_EXECUTABLE)
-	$< --rdmd=$(RDMD_TEST_EXECUTABLE) -m$(MODEL) \
+	$< $(RDMD_TEST_EXECUTABLE) -m$(MODEL) \
 	   --rdmd-default-compiler=$(RDMD_TEST_DEFAULT_COMPILER) \
 	   --test-compilers=$(RDMD_TEST_COMPILERS) \
 	   $(VERBOSE_RDMD_TEST_FLAGS)

--- a/win32.mak
+++ b/win32.mak
@@ -101,7 +101,7 @@ $(ROOT)\rdmd_test.exe : rdmd_test.d
 
 test_rdmd : $(ROOT)\rdmd_test.exe $(RDMD_TEST_EXECUTABLE)
         $(ROOT)\rdmd_test.exe \
-           --rdmd=$(RDMD_TEST_EXECUTABLE) -m$(MODEL) -v \
+           $(RDMD_TEST_EXECUTABLE) -m$(MODEL) -v \
            --rdmd-default-compiler=$(RDMD_TEST_DEFAULT_COMPILER) \
            --test-compilers=$(RDMD_TEST_COMPILERS)
 


### PR DESCRIPTION
Non-option arguments are more conventional than "required options".