### PR TITLE
rdmd: support --eval <arg> to make it Makefile friendly

### DIFF
--- a/changelog/rdmdMakefiles.dd
+++ b/changelog/rdmdMakefiles.dd
@@ -1,0 +1,12 @@
+rdmd can now be used as a shell in makefiles
+
+With gnu make(3.82 or higher), rdmd can now be used in makefiles.
+This is accomplished by setting the SHELL and .SHELLFLAGS to /usr/bin/rdmd and --eval respectively.
+---
+.ONESHELL:
+SHELL = /usr/bin/rdmd
+.SHELLFLAGS = --eval
+hello.txt:
+$(TAB)import std.file;
+$(TAB)write("$@","hello world\n");
+---

--- a/rdmd.d
+++ b/rdmd.d
@@ -329,12 +329,14 @@ int main(string[] args)
 
 size_t indexOfProgram(string[] args)
 {
-    foreach(i, arg; args[1 .. $])
+    foreach(i; 1 .. args.length)
     {
+        auto arg = args[i];
         if (!arg.startsWith('-', '@') &&
-                !arg.endsWith(".obj", ".o", ".lib", ".a", ".def", ".map", ".res"))
+                !arg.endsWith(".obj", ".o", ".lib", ".a", ".def", ".map", ".res") &&
+                args[i - 1] != "--eval")
         {
-            return i + 1;
+            return i;
         }
     }
 

--- a/travis.sh
+++ b/travis.sh
@@ -10,8 +10,15 @@ set -uexo pipefail
 GDMD=$(find ~/dlang -type f -name "gdmd")
 LDMD2=$(find ~/dlang -type f -name "ldmd2")
 
-make -f posix.mak all DMD="$(which dmd)"
-make -f posix.mak test DMD="$(which dmd)" \
+curl https://ftp.gnu.org/gnu/make/make-4.2.tar.gz | tar -xz
+cd make-4.2
+./configure
+./build.sh
+cd ..
+export MAKE=$(pwd)/make-4.2/make
+
+$MAKE -f posix.mak all DMD="$(which dmd)"
+$MAKE -f posix.mak test DMD="$(which dmd)" \
     RDMD_TEST_COMPILERS=dmd,"$GDMD","$LDMD2" \
     VERBOSE_RDMD_TEST=1
 


### PR DESCRIPTION
This a patch to make rdmd work for makefiles using a -e flag.
```
.ONESHELL:
SHELL = /usr/bin/rdmd
.SHELLFLAGS = -e 
hello.txt:
	import std.file;
	write("$@","hello world\n");
```
note --eval= won't work in SHELLFLAGS because make passes SHELLFLAGS and the code in seperate arguments.
```
Invoked with: ["/home/superstar64/Desktop/tools/rdmd", "-e", "import std.file;\nwrite(\"hello.txt\",\"hello world\\n\");"]
```