### PR TITLE
Changed --test-compilers to --compilers

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -122,7 +122,7 @@ endif
 test_rdmd: $(ROOT)/rdmd_test $(RDMD_TEST_EXECUTABLE)
 	$< $(RDMD_TEST_EXECUTABLE) -m$(MODEL) \
 	   --rdmd-default-compiler=$(RDMD_TEST_DEFAULT_COMPILER) \
-	   --test-compilers=$(RDMD_TEST_COMPILERS) \
+	   --compilers=$(RDMD_TEST_COMPILERS) \
 	   $(VERBOSE_RDMD_TEST_FLAGS)
 	$(DMD) $(DFLAGS) -unittest -main -run rdmd.d
 

--- a/rdmd_test.d
+++ b/rdmd_test.d
@@ -58,7 +58,7 @@ int main(string[] args)
         "rdmd-default-compiler", "[REQUIRED] default D compiler used by rdmd executable", &defaultCompiler,
         "concurrency", "whether to perform the concurrency test cases", &concurrencyTest,
         "m|model", "architecture to run the tests for [32 or 64]", &model,
-        "test-compilers", "comma-separated list of D compilers to test with rdmd", &testCompilerList,
+        "compilers", "comma-separated list of D compilers to test with rdmd", &testCompilerList,
         "v|verbose", "verbose output", &verbose,
     );
 

--- a/win32.mak
+++ b/win32.mak
@@ -103,6 +103,6 @@ test_rdmd : $(ROOT)\rdmd_test.exe $(RDMD_TEST_EXECUTABLE)
         $(ROOT)\rdmd_test.exe \
            $(RDMD_TEST_EXECUTABLE) -m$(MODEL) -v \
            --rdmd-default-compiler=$(RDMD_TEST_DEFAULT_COMPILER) \
-           --test-compilers=$(RDMD_TEST_COMPILERS)
+           --compilers=$(RDMD_TEST_COMPILERS)
 
 test : test_rdmd


### PR DESCRIPTION
Removed unnecessary "test-" prefix of the compilers option name.