### PR TITLE
rdmd: support -of=... and -od=... flags as well as -of... and -od...

### DIFF
--- a/rdmd.d
+++ b/rdmd.d
@@ -80,18 +80,20 @@ int main(string[] args)
     // Parse the -o option (-ofmyfile or -odmydir).
     void dashOh(string key, string value)
     {
-        if (value[0] == 'f')
+        if (value.skipOver('f'))
         {
             // -ofmyfile passed
-            exe = value[1 .. $];
+            value.skipOver('='); // support -of... and -of=...
+            exe = value;
         }
-        else if (value[0] == 'd')
+        else if (value.skipOver('d'))
         {
             // -odmydir passed
             if (!exe.ptr) // Don't let -od override -of
             {
+                value.skipOver('='); // support -od... and -od=...
+                exe = value;
                 // add a trailing dir separator to clarify it's a dir
-                exe = value[1 .. $];
                 if (!exe.endsWith(dirSeparator))
                 {
                     exe ~= dirSeparator;

--- a/rdmd.d
+++ b/rdmd.d
@@ -101,12 +101,12 @@ int main(string[] args)
                 assert(exe.endsWith(dirSeparator));
             }
         }
-        else if (value[0] == '-')
+        else if (value == "-")
         {
             // -o- passed
             enforce(false, "Option -o- currently not supported by rdmd");
         }
-        else if (value[0] == 'p')
+        else if (value == "p")
         {
             // -op passed
             preserveOutputPaths = true;

--- a/rdmd_test.d
+++ b/rdmd_test.d
@@ -432,6 +432,9 @@ void runTests(string rdmdApp, string compiler, string model)
     res = execute(rdmdArgs ~ ["-of" ~ conflictDir, forceSrc]);
     assert(res.status != 0, "-of set to a directory should fail");
 
+    res = execute(rdmdArgs ~ ["-of=" ~ conflictDir, forceSrc]);
+    assert(res.status != 0, "-of= set to a directory should fail");
+
     /* rdmd should force rebuild when --compiler changes: https://issues.dlang.org/show_bug.cgi?id=15031 */
 
     res = execute(rdmdArgs ~ [forceSrc]);
@@ -505,6 +508,12 @@ void runTests(string rdmdApp, string compiler, string model)
         res = execute(rdmdArgs ~ ["--build-only", "--force", "-lib", "-od" ~ libDir, srcName]);
         assert(res.status == 0, res.output);
         assert(exists(libDir.buildPath("test" ~ libExt)));
+
+        // test with -od= too
+        TmpDir altLibDir = "rdmdTestAltLib";
+        res = execute(rdmdArgs ~ ["--build-only", "--force", "-lib", "-od=" ~ altLibDir, srcName]);
+        assert(res.status == 0, res.output);
+        assert(exists(altLibDir.buildPath("test" ~ libExt)));
     }
 
     // Test with -of
@@ -519,6 +528,13 @@ void runTests(string rdmdApp, string compiler, string model)
         res = execute(rdmdArgs ~ ["--build-only", "--force", "-lib", "-of" ~ libName, srcName]);
         assert(res.status == 0, res.output);
         assert(exists(libName));
+
+        // test that -of= works too
+        string altLibName = libDir.buildPath("altlibtest" ~ libExt);
+
+        res = execute(rdmdArgs ~ ["--build-only", "--force", "-lib", "-of=" ~ altLibName, srcName]);
+        assert(res.status == 0, res.output);
+        assert(exists(altLibName));
     }
 
     /* rdmd --build-only --force -c main.d fails: ./main: No such file or directory: https://issues.dlang.org/show_bug.cgi?id=16962 */

--- a/rdmd_test.d
+++ b/rdmd_test.d
@@ -158,6 +158,19 @@ void runCompilerAgnosticTests(string rdmdApp, string defaultCompiler, string mod
         assert(defaultCompiler.baseName == compilerInHelp);
     }
 
+    /* Test that unsupported -o... options result in failure */
+    res = execute([rdmdApp, "-o-"]);  // valid option for dmd but unsupported by rdmd
+    assert(res.status == 1, res.output);
+    assert(res.output.canFind("Option -o- currently not supported by rdmd"), res.output);
+
+    res = execute([rdmdApp, "-o-foo"]); // should not be treated the same as -o-
+    assert(res.status == 1, res.output);
+    assert(res.output.canFind("Unrecognized option: o-foo"), res.output);
+
+    res = execute([rdmdApp, "-opbreak"]); // should not be treated like valid -op
+    assert(res.status == 1, res.output);
+    assert(res.output.canFind("Unrecognized option: opbreak"), res.output);
+
     // run the fallback compiler test (this involves
     // searching for the default compiler, so cannot
     // be run with other test compilers)


### PR DESCRIPTION
This fixes a discrepancy between `rdmd` and `dmd` in terms of the output flags they support: `dmd` now requests `-of=...` and `-od=...` in help output but still supports the old `-of...` and `-od...` style, while `rdmd` was still supporting only the older variant.

The fix itself is a bit of a hacky tweak to the `dashOh` callback used to parse `-o` flags via `getopt`.  It seemed the simplest way to fix the issue without a more intrusive rewrite of how `-o` flags are parsed.

Extra test cases have been added to `rdmd_test` to cover this, although the way this has been done is a little bit cheeky too (it turns out the only place where `-of` and `-od` are really tested rigorously in their behaviour is in tests for the case where the output file is a library in a subdirectory).  Probably at some point it would be a good idea to add some more general/rigorous test cases for the `-o...` flags, but in the short term the tests added in this patch should validate the changes to `rdmd` itself.