### PR TITLE
Fix Issue 18433 - rdmd doesn't respect DFLAGS for its cache hash

### DIFF
--- a/rdmd.d
+++ b/rdmd.d
@@ -231,7 +231,8 @@ int main(string[] args)
     }
 
     // Compute the object directory and ensure it exists
-    immutable workDir = getWorkPath(root, compilerFlags);
+    auto environmentFlags = environment.get("DFLAGS", "").split(" ");
+    immutable workDir = getWorkPath(root, compilerFlags ~ environmentFlags);
     lockWorkPath(workDir); // will be released by the OS on process exit
     string objDir = buildPath(workDir, "objs");
     Filesystem.mkdirRecurseIfLive(objDir);

--- a/rdmd_test.d
+++ b/rdmd_test.d
@@ -637,6 +637,27 @@ SHELL = %s
         assert(res.status == 0, res.output);
         assert(std.file.read(textOutput) == "hello world\n");
     }
+
+    // https://issues.dlang.org/show_bug.cgi?id=18423
+    // rdmd ignores changes in DFLAGS
+    {
+        string srcName = tempDir().buildPath("force_rebuild_dflags.d");
+        std.file.write(srcName, `void main() { import std.stdio; version(Foo) {"foo".writeln;} else { "bar".writeln; }}`);
+
+        res = execute(rdmdArgs ~ [srcName]);
+        assert(res.status == 0, res.output);
+        assert(res.output.canFind("bar"));
+
+        environment["DFLAGS"] = "-version=Foo";
+        res = execute(rdmdArgs ~ [srcName]);
+        assert(res.status == 0, res.output);
+        assert(res.output.canFind("foo"), res.output);
+
+        environment.remove("DFLAGS");
+        res = execute(rdmdArgs ~ [srcName]);
+        assert(res.status == 0, res.output);
+        assert(res.output.canFind("bar"));
+    }
 }
 
 void runConcurrencyTest(string rdmdApp, string compiler, string model)


### PR DESCRIPTION
Note this is only part of the required fix.
DMD at the moment doesn't allow to incrementally add to DFLAGS, so this needs to be fixed before this can be merged:


```
> DFLAGS="-version=Foo" ../dmd/generated/linux/release/64/dmd -c -v foo.d

predefs   DigitalMars Posix linux ELFv1 LittleEndian D_Version2 all D_SIMD D_InlineAsm_X86_64 X86_64 CRuntime_Glibc D_LP64 D_PIC assert D_HardFloat
binary    ../dmd/generated/linux/release/64/dmd
version   v2.079.0-284-g23b2e2e0d
config    ../dmd/generated/linux/release/64/dmd.conf
DFLAGS    -I../dmd/generated/linux/release/64/../../../../../druntime/import -I../dmd/generated/linux/release/64/../../../../../phobos -L-L../dmd/generated/linux/release/64/../../../../../phobos/generated/linux/release/64 -L--export-dynamic -fPIC
```

(no `Foo` set here)


```
> DFLAGS="-version=Foo" dmd -conf= -I~/dlang/phobos -I~/dlang/druntime/import -c -v foo.d

predefs   Foo DigitalMars Posix linux ELFv1 LittleEndian D_Version2 all D_SIMD D_InlineAsm_X86_64 X86_64 CRuntime_Glibc D_LP64 D_PIC assert D_HardFloat
binary    /home/seb/dlang/dmd/generated/linux/release/64/dmd
version   v2.079.0-284-g23b2e2e0d
config    
DFLAGS    -version=Foo
```

Fixes #424 