### PR TITLE
rdmd: Add --objdir option

### DIFF
--- a/man/man1/rdmd.1
+++ b/man/man1/rdmd.1
@@ -78,6 +78,10 @@ Print dependencies in makefile format to file and continue
 .IP --man
 Open web browser on manual page
 
+.IP --objdir=\fIobj_dir_path\fR
+Specify directory to store compiled object files
+[default = \fItmp_dir_path\fR/objs]
+
 .IP --tmpdir=\fItmp_dir_path\fR
 Specify directory to store cached program and other
 temporaries [default = as per \fIhttp://dlang.org/phobos/std_file.html#.tempDir\fR]

--- a/rdmd_test.d
+++ b/rdmd_test.d
@@ -552,6 +552,19 @@ void runTests(string rdmdApp, string compiler, string model)
         enforce(exists(altLibName));
     }
 
+    // Test --objdir
+    {
+        TmpDir srcDir = "rdmdTestSrc";
+        TmpDir objDir = "rdmdTestObj";
+
+        string srcName = srcDir.buildPath("test.d");
+        std.file.write(srcName, `void main() {}`);
+
+        res = execute(rdmdArgs ~ ["--build-only", "--force", "--objdir=" ~ objDir, srcName]);
+        enforce(res.status == 0, res.output);
+        enforce(exists(objDir.buildPath("test" ~ objExt)));
+    }
+
     /* rdmd --build-only --force -c main.d fails: ./main: No such file or directory: https://issues.dlang.org/show_bug.cgi?id=16962 */
     {
         TmpDir srcDir = "rdmdTest";


### PR DESCRIPTION
Sometimes, when messing with various toolchains / debugging linking problems, it's useful to look at the object files generated by the compiler.

Currently, rdmd unconditionally places them in a temporary directory, and (also unconditionally) deletes them on exit. `-od` is never passed on to the compiler, instead it's usurped by rdmd to specify the location where to place the final executable.

This introduces a new switch which allows specifying a custom directory to place object files in.
A check was already present to ensure we don't clean up a directory outside the temporary work directory (which might contain other files), which previously apparently only had an effect with `-lib` (due to a workaround for how `dmd` parses `-lib` paths).