### PR TITLE
Allow using the tools repo via DUB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 GNUmakefile
 /.dub
 /tests_extractor
+/dtools_*
+/dub.selections.json

--- a/dub.sdl
+++ b/dub.sdl
@@ -1,0 +1,74 @@
+name "dtools"
+description "D Tools"
+authors "DLang Community"
+copyright "Copyright © 1999-2018, The D Language Foundation"
+license "BSL-1.0"
+targetType "none"
+
+subPackage {
+  name "tests_extractor"
+  targetType "executable"
+  dependency "libdparse" version="~>0.8.0"
+  sourceFiles "tests_extractor.d"
+}
+
+subPackage {
+  name "dman"
+  targetType "executable"
+  sourceFiles "dman.d"
+  stringImportPaths "."
+}
+
+subPackage {
+  name "dget"
+  targetType "executable"
+  sourceFiles "dget.d"
+}
+
+subPackage {
+  name "checkwhitespace"
+  targetType "executable"
+  sourceFiles "checkwhitespace.d"
+}
+
+subPackage {
+  name "ddemangle"
+  targetType "executable"
+  sourceFiles "ddemangle.d"
+}
+
+subPackage {
+  name "detab"
+  targetType "executable"
+  sourceFiles "detab.d"
+}
+
+subPackage {
+  name "tolf"
+  targetType "executable"
+  sourceFiles "tolf.d"
+}
+
+subPackage {
+  name "rdmd"
+  targetType "executable"
+  sourceFiles "rdmd.d"
+}
+
+subPackage {
+  name "contributors"
+  targetType "executable"
+  sourceFiles "contributors.d"
+}
+
+subPackage {
+  name "changed"
+  targetType "executable"
+  sourceFiles "changed.d"
+}
+
+subPackage {
+  name "catdoc"
+  targetType "executable"
+  sourceFiles "catdoc.d"
+}

--- a/test/test_dub.sh
+++ b/test/test_dub.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Test building of all DUB packages
+
+set -euo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# dman is excluded in this test because it requires the d-tags.json file for building
+for package in tests_extractor dget checkwhitespace ddemangle detab tolf \
+               rdmd contributors changed catdoc ; do
+    echo "Testing DUB build of $package"
+    dub build --root "$DIR/.." ":$package"
+done

--- a/tests_extractor.d
+++ b/tests_extractor.d
@@ -1,7 +1,7 @@
 #!/usr/bin/env dub
 /++dub.sdl:
 name "tests_extractor"
-dependency "libdparse" version="~>0.7.2-alpha.4"
+dependency "libdparse" version="~>0.8.0"
 +/
 /*
  * Parses all public unittests that are visible on dlang.org

--- a/travis.sh
+++ b/travis.sh
@@ -45,3 +45,6 @@ popd && rm -rf "$dir" && mkdir "$dir" && pushd "$dir"
 echo "y" | "$cwd"/setup.sh --tag=2.078.1
 echo 'void main(){ import std.stdio; __VERSION__.writeln;}' | "./2.078.1/${dmd}" -run - | grep -q "2078"
 popd
+
+# test building the DUB packages
+./test/test_dub.sh


### PR DESCRIPTION
Allows using the tools from anywhere with e.g.

```
dub run dtools:tests_extractor
dub run dtools:detab
```