### PR TITLE
Add information about the --shebang switch to the rdmd man page.

### DIFF
--- a/man/man1/rdmd.1
+++ b/man/man1/rdmd.1
@@ -79,7 +79,11 @@ Print dependencies in makefile format to file and continue
 Open web browser on manual page
 
 .IP --shebang
-On some operating systems (e.g. Linux) all of the arguments to the interpreter in a shebang line are passed as one concatenated string.  In such an environment if you need to supply multiple options to rdmd, place this option before any others.  This will cause rdmd to parse the string and extract all of the options.
+On some operating systems (e.g. Linux) all of the arguments to the interpreter
+in a shebang line are passed as one concatenated string.  In such an 
+environment if you need to supply multiple options to rdmd, place this option
+before any others.  This will cause rdmd to parse the string and extract all 
+of the options.
 
 .IP --tmpdir=\fItmp_dir_path\fR
 Specify directory to store cached program and other

--- a/man/man1/rdmd.1
+++ b/man/man1/rdmd.1
@@ -78,6 +78,9 @@ Print dependencies in makefile format to file and continue
 .IP --man
 Open web browser on manual page
 
+.IP --shebang
+On some operating systems (e.g. Linux) all of the arguments to the interpreter in a shebang line are passed as one concatenated string.  In such an environment if you need to supply multiple options to rdmd, place this option before any others.  This will cause rdmd to parse the string and extract all of the options.
+
 .IP --tmpdir=\fItmp_dir_path\fR
 Specify directory to store cached program and other
 temporaries [default = as per \fIhttp://dlang.org/phobos/std_file.html#.tempDir\fR]


### PR DESCRIPTION
The first place I looked for information/help was the man page but information on the --shebang option is missing (although it does appear in the --help text).

As a result, it took me far too long to find this information - I eventually found the information on a forum post somewhere after a few fruitless searches - adding it to the man page will hopefully save someone else from doing the same if they look there first.