### PR TITLE
Build DustMite with -version=Dlang_Tools

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -74,7 +74,7 @@ dman:      $(ROOT)/dman
 dustmite:  $(ROOT)/dustmite
 
 $(ROOT)/dustmite: DustMite/dustmite.d DustMite/splitter.d
-	$(DMD) $(DFLAGS) DustMite/dustmite.d DustMite/splitter.d -of$(@)
+	$(DMD) $(DFLAGS) -version=Dlang_Tools DustMite/dustmite.d DustMite/splitter.d -of$(@)
 
 $(TOOLS) $(DOC_TOOLS) $(CURL_TOOLS) $(TEST_TOOLS): $(ROOT)/%: %.d
 	$(DMD) $(DFLAGS) -of$(@) $(<)

--- a/win32.mak
+++ b/win32.mak
@@ -66,7 +66,7 @@ $(ROOT)\ddemangle.exe : ddemangle.d
 	$(DMD) $(DFLAGS) -of$@ ddemangle.d
 
 $(ROOT)\dustmite.exe : DustMite/dustmite.d DustMite/splitter.d
-	$(DMD) $(DFLAGS) -of$@ DustMite/dustmite.d DustMite/splitter.d
+	$(DMD) $(DFLAGS) -of$@ -version=Dlang_Tools DustMite/dustmite.d DustMite/splitter.d
 
 $(ROOT)\changed.exe : changed.d
 	$(DMD) $(DFLAGS) -of$@ changed.d


### PR DESCRIPTION
To identify the source in `dustmite --version`.

Complement of https://github.com/CyberShadow/DustMite/commit/ad0877db8a83a790845ebbc52c16e0a5b38032e6 for https://github.com/CyberShadow/DustMite/issues/55.