### PR TITLE
Parse unittest attributes and write them to the publictest tester

### DIFF
--- a/test/tests_extractor/ascii.d.ext
+++ b/test/tests_extractor/ascii.d.ext
@@ -1,5 +1,5 @@
 # line 107
-unittest
+@safe @nogc unittest
 {
     import std.ascii;
 
@@ -12,7 +12,7 @@ unittest
 }
 
 # line 138
-unittest
+@safe @nogc unittest
 {
     import std.ascii;
 
@@ -25,7 +25,7 @@ unittest
 }
 
 # line 168
-unittest
+@safe @nogc unittest
 {
     import std.ascii;
 
@@ -39,7 +39,7 @@ unittest
 }
 
 # line 199
-unittest
+@safe @nogc unittest
 {
     import std.ascii;
 
@@ -53,7 +53,7 @@ unittest
 }
 
 # line 230
-unittest
+@safe @nogc unittest
 {
     import std.ascii;
 
@@ -68,7 +68,7 @@ unittest
 }
 
 # line 262
-unittest
+@safe @nogc unittest
 {
     import std.ascii;
 
@@ -80,7 +80,7 @@ unittest
 }
 
 # line 291
-unittest
+@safe @nogc unittest
 {
     import std.ascii;
 
@@ -93,7 +93,7 @@ unittest
 }
 
 # line 323
-unittest
+@safe @nogc unittest
 {
     import std.ascii;
 
@@ -111,7 +111,7 @@ unittest
 }
 
 # line 358
-unittest
+@safe @nogc unittest
 {
     import std.ascii;
 
@@ -130,7 +130,7 @@ unittest
 }
 
 # line 397
-unittest
+@safe @nogc unittest
 {
     import std.ascii;
 
@@ -154,7 +154,7 @@ unittest
 }
 
 # line 441
-unittest
+@safe @nogc unittest
 {
     import std.ascii;
 
@@ -170,7 +170,7 @@ unittest
 }
 
 # line 477
-unittest
+@safe @nogc unittest
 {
     import std.ascii;
 
@@ -185,7 +185,7 @@ unittest
 }
 
 # line 513
-unittest
+@safe @nogc unittest
 {
     import std.ascii;
 
@@ -194,7 +194,7 @@ unittest
 }
 
 # line 554
-unittest
+@safe @nogc unittest
 {
     import std.ascii;
 
@@ -207,7 +207,7 @@ unittest
 }
 
 # line 616
-unittest
+@safe @nogc unittest
 {
     import std.ascii;
 

--- a/test/tests_extractor/attributes.d.ext
+++ b/test/tests_extractor/attributes.d.ext
@@ -1,5 +1,5 @@
 # line 3
-unittest
+@safe unittest
 {
     import attributes;
 
@@ -23,7 +23,7 @@ unittest
 }
 
 # line 29
-unittest
+@nogc @safe unittest
 {
     import attributes;
 

--- a/test/tests_extractor/iteration.d.ext
+++ b/test/tests_extractor/iteration.d.ext
@@ -1,5 +1,5 @@
 # line 163
-unittest
+@safe unittest
 {
     import std.algorithm.iteration;
 
@@ -43,7 +43,7 @@ unittest
 }
 
 # line 218
-unittest
+@safe unittest
 {
     import std.algorithm.iteration;
 
@@ -63,7 +63,7 @@ unittest
 }
 
 # line 495
-unittest
+@safe unittest
 {
     import std.algorithm.iteration;
 
@@ -76,7 +76,7 @@ unittest
 }
 
 # line 510
-unittest
+@safe unittest
 {
     import std.algorithm.iteration;
 
@@ -93,7 +93,7 @@ unittest
 }
 
 # line 528
-unittest
+@safe unittest
 {
     import std.algorithm.iteration;
 
@@ -105,7 +105,7 @@ unittest
 }
 
 # line 955
-unittest
+@system unittest
 {
     import std.algorithm.iteration;
 
@@ -148,7 +148,7 @@ unittest
 }
 
 # line 1100
-unittest
+@safe unittest
 {
     import std.algorithm.iteration;
 
@@ -179,7 +179,7 @@ unittest
 }
 
 # line 1320
-unittest
+@safe unittest
 {
     import std.algorithm.iteration;
 
@@ -200,7 +200,7 @@ unittest
 }
 
 # line 1502
-unittest
+@safe unittest
 {
     import std.algorithm.iteration;
 
@@ -213,7 +213,7 @@ unittest
 }
 
 # line 1516
-unittest
+@safe unittest
 {
     import std.algorithm.iteration;
 
@@ -230,7 +230,7 @@ unittest
 }
 
 # line 1907
-unittest
+@system unittest
 {
     import std.algorithm.iteration;
 
@@ -259,7 +259,7 @@ unittest
 }
 
 # line 1957
-unittest
+@system unittest
 {
     import std.algorithm.iteration;
 
@@ -311,7 +311,7 @@ unittest
 }
 
 # line 2280
-unittest
+@safe unittest
 {
     import std.algorithm.iteration;
 
@@ -328,7 +328,7 @@ unittest
 }
 
 # line 2883
-unittest
+@safe unittest
 {
     import std.algorithm.iteration;
 
@@ -378,7 +378,7 @@ unittest
 }
 
 # line 2938
-unittest
+@safe unittest
 {
     import std.algorithm.iteration;
 
@@ -403,7 +403,7 @@ unittest
 }
 
 # line 3210
-unittest
+@safe unittest
 {
     import std.algorithm.iteration;
 
@@ -432,7 +432,7 @@ unittest
 }
 
 # line 3418
-unittest
+@safe unittest
 {
     import std.algorithm.iteration;
 
@@ -483,7 +483,7 @@ unittest
 }
 
 # line 3474
-unittest
+@safe unittest
 {
     import std.algorithm.iteration;
 
@@ -506,7 +506,7 @@ unittest
 }
 
 # line 3831
-unittest
+@safe unittest
 {
     import std.algorithm.iteration;
 
@@ -525,7 +525,7 @@ unittest
 }
 
 # line 4069
-unittest
+@safe unittest
 {
     import std.algorithm.iteration;
 
@@ -542,7 +542,7 @@ unittest
 }
 
 # line 4218
-unittest
+@safe unittest
 {
     import std.algorithm.iteration;
 
@@ -562,7 +562,7 @@ unittest
 }
 
 # line 4507
-unittest
+@safe unittest
 {
     import std.algorithm.iteration;
 
@@ -572,7 +572,7 @@ unittest
 }
 
 # line 4820
-unittest
+@safe unittest
 {
     import std.algorithm.iteration;
 
@@ -604,7 +604,7 @@ unittest
 }
 
 # line 4952
-unittest
+@safe unittest
 {
     import std.algorithm.iteration;
 
@@ -625,7 +625,7 @@ unittest
 }
 
 # line 5178
-unittest
+@safe unittest
 {
     import std.algorithm.iteration;
 

--- a/tests_extractor.d
+++ b/tests_extractor.d
@@ -70,7 +70,7 @@ class TestVisitor : ASTVisitor
     override void visit(const Declaration decl)
     {
         if (decl.unittest_ !is null && shouldIncludeUnittest(decl))
-            print(decl.unittest_);
+            print(decl.unittest_, decl.attributes);
 
         decl.accept(this);
     }
@@ -117,7 +117,7 @@ private:
         }
         return false;
     }
-    void print(const Unittest u)
+    void print(const Unittest u, const Attribute[] attributes)
     {
         /*
         Write the origin source code line
@@ -126,6 +126,24 @@ private:
         the top of the unittest.
         */
         outFile.writefln("# line %d", u.line > 2 ? u.line - 2 : 0);
+
+        static immutable predefinedAttributes = ["nogc", "system", "nothrow", "safe", "trusted", "pure"];
+
+        // write system attributes
+        foreach (attr; attributes)
+        {
+            const atAttribute = attr.atAttribute;
+            if (atAttribute is null)
+                continue;
+
+            const atText = atAttribute.identifier.text;
+
+            // ignore custom attributes (@myArg)
+            if (!predefinedAttributes.canFind(atText))
+                continue;
+
+            outFile.write(text("@", atText, " "));
+        }
 
         // write the unittest block
         outFile.write("unittest\n{\n");


### PR DESCRIPTION
While the underlying issue is https://issues.dlang.org/show_bug.cgi?id=19873, fixing this allows the Phobos PR to move on for now.

tl;dr: the publictest extractor now extracts the respective system attributes too.

Required for https://github.com/dlang/phobos/pull/6931