### PR TITLE
tests_extractor: extract pure + nothrow too

### DIFF
--- a/test/tests_extractor/ascii.d.ext
+++ b/test/tests_extractor/ascii.d.ext
@@ -1,5 +1,5 @@
 # line 107
-@safe @nogc unittest
+@safe pure nothrow @nogc unittest
 {
     import std.ascii;
 
@@ -12,7 +12,7 @@
 }
 
 # line 138
-@safe @nogc unittest
+@safe pure nothrow @nogc unittest
 {
     import std.ascii;
 
@@ -25,7 +25,7 @@
 }
 
 # line 168
-@safe @nogc unittest
+@safe pure nothrow @nogc unittest
 {
     import std.ascii;
 
@@ -39,7 +39,7 @@
 }
 
 # line 199
-@safe @nogc unittest
+@safe pure nothrow @nogc unittest
 {
     import std.ascii;
 
@@ -53,7 +53,7 @@
 }
 
 # line 230
-@safe @nogc unittest
+@safe pure nothrow @nogc unittest
 {
     import std.ascii;
 
@@ -68,7 +68,7 @@
 }
 
 # line 262
-@safe @nogc unittest
+@safe pure nothrow @nogc unittest
 {
     import std.ascii;
 
@@ -80,7 +80,7 @@
 }
 
 # line 291
-@safe @nogc unittest
+@safe pure nothrow @nogc unittest
 {
     import std.ascii;
 
@@ -93,7 +93,7 @@
 }
 
 # line 323
-@safe @nogc unittest
+@safe pure nothrow @nogc unittest
 {
     import std.ascii;
 
@@ -111,7 +111,7 @@
 }
 
 # line 358
-@safe @nogc unittest
+@safe pure nothrow @nogc unittest
 {
     import std.ascii;
 
@@ -130,7 +130,7 @@
 }
 
 # line 397
-@safe @nogc unittest
+@safe pure nothrow @nogc unittest
 {
     import std.ascii;
 
@@ -154,7 +154,7 @@
 }
 
 # line 441
-@safe @nogc unittest
+@safe pure nothrow @nogc unittest
 {
     import std.ascii;
 
@@ -170,7 +170,7 @@
 }
 
 # line 477
-@safe @nogc unittest
+@safe pure nothrow @nogc unittest
 {
     import std.ascii;
 
@@ -185,7 +185,7 @@
 }
 
 # line 513
-@safe @nogc unittest
+@safe pure nothrow @nogc unittest
 {
     import std.ascii;
 
@@ -194,7 +194,7 @@
 }
 
 # line 554
-@safe @nogc unittest
+@safe pure nothrow @nogc unittest
 {
     import std.ascii;
 
@@ -207,7 +207,7 @@
 }
 
 # line 616
-@safe @nogc unittest
+@safe pure nothrow @nogc unittest
 {
     import std.ascii;
 

--- a/test/tests_extractor/iteration.d.ext
+++ b/test/tests_extractor/iteration.d.ext
@@ -403,7 +403,7 @@
 }
 
 # line 3210
-@safe unittest
+@safe pure unittest
 {
     import std.algorithm.iteration;
 
@@ -562,7 +562,7 @@
 }
 
 # line 4507
-@safe unittest
+@safe pure unittest
 {
     import std.algorithm.iteration;
 
@@ -572,7 +572,7 @@
 }
 
 # line 4820
-@safe unittest
+@safe pure nothrow unittest
 {
     import std.algorithm.iteration;
 

--- a/tests_extractor.d
+++ b/tests_extractor.d
@@ -132,6 +132,14 @@ private:
         // write system attributes
         foreach (attr; attributes)
         {
+            // pure and nothrow
+            if (attr.attribute.type != 0)
+            {
+                import dparse.lexer : str;
+                const attrText = attr.attribute.type.str;
+                outFile.write(text(attrText, " "));
+            }
+
             const atAttribute = attr.atAttribute;
             if (atAttribute is null)
                 continue;


### PR DESCRIPTION
They are handled differently in libdparse, but while I was at it, it's probably a good idea to support them too to avoid any potential confusion.

See also: https://github.com/dlang/tools/pull/369