### PR TITLE
Have tolf keep and/or add terminating newline

### DIFF
--- a/tolf.d
+++ b/tolf.d
@@ -7,12 +7,12 @@
 /* Replace line endings with LF
  */
 
-import std.file, std.path, std.string;
+import std.file, std.path, std.string, std.range;
 
 void main(string[] args)
 {
     foreach (f; args[1 .. $])
         if (f.exists)
-            f.write(f.readText.lineSplitter.join('\n'));
+            f.write(f.readText.lineSplitter.chain([""]).join('\n'));
 }
 


### PR DESCRIPTION
Currently `tolf` will remove terminating newlines from files.  This PR modifies it to keep the existing trailing newline if there is one, or add it if it doesn't have one.  This causes `tolf` to modify files according to the posix standard (see https://forum.dlang.org/post/mailman.1025.1573349185.8294.digitalmars-d@puremagic.com for reference).