### PR TITLE
Add email duplicate for Berni

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -18,6 +18,8 @@ Andrey Zherikov <andrey.zherikov@gmail.com>
 Aurélien Fredouelle <aurelien.fredouelle@gmail.com>
 Basile Burg <b2.temp@gmx.com> <basile.b@gmx.com> <Basile-z@users.noreply.github.com> <Basile-z> <BBasile>
 Benjamin L. Merritt <blm768@gmail.com>
+Bernhard Seckinger <github@d-ecke.de>
+Bernhard Seckinger <github@d-ecke.de> <56265324+berni44@users.noreply.github.com>
 Boris Carvajal <boris2.9@gmail.com>
 Brad Anderson <root>
 Brian Schott <briancschott@gmail.com>


### PR DESCRIPTION
Alternative to #388, because in 388 my name and my email address are wrong; see my comment there.