### PR TITLE
Use system make for tests

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -10,15 +10,8 @@ set -uexo pipefail
 GDMD=$(find ~/dlang -type f -name "gdmd")
 LDMD2=$(find ~/dlang -type f -name "ldmd2")
 
-curl https://ftp.gnu.org/gnu/make/make-4.2.tar.gz | tar -xz
-cd make-4.2
-./configure
-./build.sh
-cd ..
-export MAKE=$(pwd)/make-4.2/make
-
-$MAKE -f posix.mak all DMD="$(which dmd)"
-$MAKE -f posix.mak test DMD="$(which dmd)" \
+make -f posix.mak all DMD="$(which dmd)"
+make -f posix.mak test DMD="$(which dmd)" \
     RDMD_TEST_COMPILERS=dmd,"$GDMD","$LDMD2" \
     VERBOSE_RDMD_TEST=1
 


### PR DESCRIPTION
```
The installation of make was added in PR 336 as at that time Travis
was using Ubuntu 14.04 which had make 3.81, whereas 3.82 is required
for the test.
Nowadays Travis uses either 16.04 or 18.04, and 16.04 comes with make 4.1.
```

Just put the `make --version` in there to double check my sanity.
Version of make can be checked here: https://packages.ubuntu.com/search?keywords=make