### PR TITLE
Add win64.mak

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -67,3 +67,5 @@ test_script:
  - '%DC% --version'
  - make -f win32.mak DFLAGS=-g rdmd dustmite ddemangle changed
  - make -f win32.mak DFLAGS=-g test
+ - make -f win64.mak DFLAGS=-g rdmd dustmite ddemangle changed
+ - make -f win64.mak DFLAGS=-g test

--- a/win32.mak
+++ b/win32.mak
@@ -28,7 +28,7 @@ ZIP=zip32
 # Copy to another directory
 SCP=$(CP)
 
-DFLAGS=-O -release
+DFLAGS=-O -release -m$(MODEL)
 
 GENERATED = generated
 ROOT = $(GENERATED)\windows\32
@@ -39,7 +39,7 @@ TARGETS=	$(ROOT)\dman.exe \
 	$(ROOT)\changed.exe \
 	$(ROOT)\dustmite.exe
 
-MAKEFILES=win32.mak posix.mak
+MAKEFILES=win32.mak win64.mak posix.mak
 
 SRCS=dman.d rdmd.d ddemangle.d
 

--- a/win64.mak
+++ b/win64.mak
@@ -1,0 +1,64 @@
+ROOT = generated\windows\64
+
+TARGETS=	$(ROOT)\dman.exe \
+	$(ROOT)\rdmd.exe \
+	$(ROOT)\ddemangle.exe \
+	$(ROOT)\changed.exe \
+	$(ROOT)\dustmite.exe
+
+targets : $(TARGETS)
+
+dman:      $(ROOT)\dman.exe
+rdmd:      $(ROOT)\rdmd.exe
+ddemangle: $(ROOT)\ddemangle.exe
+changed:   $(ROOT)\changed.exe
+dustmite:  $(ROOT)\dustmite.exe
+
+d-tags.json :
+	@echo 'Build d-tags.json and copy it here, e.g. by running:'
+	@echo "    make -C ../dlang.org -f win64.mak d-tags.json && copy ../dlang.org/d-tags-latest.json d-tags.json"
+	@exit
+
+MAKE_WIN32=make -f win32.mak "ROOT=$(ROOT)" "MODEL=$(MODEL)"
+
+$(ROOT)\dman.exe : dman.d d-tags.json
+	$(MAKE_WIN32) $@
+
+$(ROOT)\rdmd.exe : rdmd.d
+	$(MAKE_WIN32) $@
+
+$(ROOT)\ddemangle.exe : ddemangle.d
+	$(MAKE_WIN32) $@
+
+$(ROOT)\dustmite.exe : DustMite/dustmite.d DustMite/splitter.d DustMite/polyhash.d
+	$(MAKE_WIN32) $@
+
+$(ROOT)\changed.exe : changed.d
+	$(MAKE_WIN32) $@
+
+clean :
+	$(MAKE_WIN32) $@
+
+detab:
+	$(MAKE_WIN32) $@
+
+tolf:
+	$(MAKE_WIN32) $@
+
+zip: detab tolf $(MAKEFILES)
+	$(MAKE_WIN32) $@
+
+scp: detab tolf $(MAKEFILES)
+	$(MAKE_WIN32) $@
+
+
+################################################################################
+# Build and run tests
+################################################################################
+$(ROOT)\rdmd_test.exe : rdmd_test.d
+	$(MAKE_WIN32) $@
+
+test_rdmd : $(ROOT)\rdmd_test.exe $(RDMD_TEST_EXECUTABLE)
+	$(MAKE_WIN32) $@
+
+test : test_rdmd


### PR DESCRIPTION
This is added so that the windows installer can use it to build the tools for the 64-bit version also. The file is mostly copy-paste from win32.mak.