### PR TITLE
Fix LDC arm64 build

### DIFF
--- a/osmodel.mak
+++ b/osmodel.mak
@@ -1,0 +1,75 @@
+#   osmodel.mak
+#
+# Detects and sets the macros:
+#
+#   OS         = one of {osx,linux,freebsd,openbsd,netbsd,dragonflybsd,solaris}
+#   MODEL      = one of { 32, 64 }
+#   MODEL_FLAG = one of { -m32, -m64 }
+#   ARCH       = one of { x86, x86_64, aarch64 }
+#
+# Note:
+#   Keep this file in sync between druntime, phobos, and dmd repositories!
+# Source: https://github.com/dlang/dmd/blob/master/src/osmodel.mak
+
+
+ifeq (,$(OS))
+  uname_S:=$(shell uname -s)
+  ifeq (Darwin,$(uname_S))
+    OS:=osx
+  endif
+  ifeq (Linux,$(uname_S))
+    OS:=linux
+  endif
+  ifeq (FreeBSD,$(uname_S))
+    OS:=freebsd
+  endif
+  ifeq (OpenBSD,$(uname_S))
+    OS:=openbsd
+  endif
+  ifeq (NetBSD,$(uname_S))
+    OS:=netbsd
+  endif
+  ifeq (DragonFly,$(uname_S))
+    OS:=dragonflybsd
+  endif
+  ifeq (Solaris,$(uname_S))
+    OS:=solaris
+  endif
+  ifeq (SunOS,$(uname_S))
+    OS:=solaris
+  endif
+  ifeq (,$(OS))
+    $(error Unrecognized or unsupported OS for uname: $(uname_S))
+  endif
+endif
+
+# When running make from XCode it may set environment var OS=MACOS.
+# Adjust it here:
+ifeq (MACOS,$(OS))
+  OS:=osx
+endif
+
+ifeq (,$(MODEL))
+  ifeq ($(OS), solaris)
+    uname_M:=$(shell isainfo -n)
+  else
+    uname_M:=$(shell uname -m)
+  endif
+  ifneq (,$(findstring $(uname_M),x86_64 amd64))
+    MODEL:=64
+    ARCH:=x86_64
+  endif
+  ifneq (,$(findstring $(uname_M),aarch64 arm64))
+    MODEL:=64
+    ARCH:=aarch64
+  endif
+  ifneq (,$(findstring $(uname_M),i386 i586 i686))
+    MODEL:=32
+    ARCH:=x86
+  endif
+  ifeq (,$(MODEL))
+    $(error Cannot figure 32/64 model and arch from uname -m: $(uname_M))
+  endif
+endif
+
+MODEL_FLAG:=-m$(MODEL)

--- a/posix.mak
+++ b/posix.mak
@@ -10,9 +10,8 @@ DUB=dub
 WITH_DOC = no
 DOC = ../dlang.org
 
-# Load operating system $(OS) (e.g. linux, osx, ...) and $(MODEL) (e.g. 32, 64) detection Makefile from dmd
-$(shell [ ! -d $(DMD_DIR) ] && git clone --depth=1 https://github.com/dlang/dmd $(DMD_DIR))
-include $(DMD_DIR)/src/osmodel.mak
+# Load operating system $(OS) (e.g. linux, osx, ...) and $(MODEL) (e.g. 32, 64) detection Makefile
+include osmodel.mak
 
 # Build folder for all binaries
 GENERATED = generated
@@ -39,8 +38,8 @@ DFLAGS = -I$(DRUNTIME_PATH)/import -I$(PHOBOS_PATH) \
 		 -L-L$(PHOBOS_PATH)/generated/$(OS)/$(BUILD)/$(MODEL) $(MODEL_FLAG) -fPIC -preview=dip1000
 DFLAGS += $(WARNINGS)
 
-# Default DUB flags (DUB uses a different architecture format)
-DUBFLAGS = --arch=$(subst 32,x86,$(subst 64,x86_64,$(MODEL)))
+# Default DUB flags
+DUBFLAGS = --arch=$(ARCH)
 
 TOOLS = \
     $(ROOT)/catdoc \


### PR DESCRIPTION
This improves upon https://github.com/dlang/dmd/pull/13288 and adds a copy of `osmodel.mak` into this repo, to break the build dependency between the two repos. This allows one to build the tools with `ldc`, without the need to clone `dmd`.

This PR also adds a new make var `ARCH` which is the llvm/dub compatible architecture (ie. `x86_64`, `x86`, or `aarch64`). This replaces the previous `subst` hack on line 42, which could never recover `arm64` from just the `MODEL` 64. 

Related bugzilla, raising a similar issue: https://issues.dlang.org/show_bug.cgi?id=22078