### PR TITLE
rdmd: Allow selection of default compiler independent from the host one

### DIFF
--- a/rdmd.d
+++ b/rdmd.d
@@ -47,7 +47,16 @@ immutable string[] defaultExclusions = ["std", "etc", "core"];
 private string[] exclusions = defaultExclusions; // packages that are to be excluded
 private string[] extraFiles = [];
 
-version (DigitalMars)
+// Override compiler at build time
+version (DefaultCompiler_DMD)
+    private enum defaultCompiler = "dmd";
+else version (DefaultCompiler_GDC)
+    private enum defaultCompiler = "gdmd";
+else version (DefaultCompiler_LDC)
+    private enum defaultCompiler = "ldmd2";
+
+// Default to the current host compiler if no default was specified
+else version (DigitalMars)
     private enum defaultCompiler = "dmd";
 else version (GNU)
     private enum defaultCompiler = "gdmd";


### PR DESCRIPTION
Extends the `defaultCompiler` selection s.t. custom defaults can be selected at compile time via `-version=DefaultCompiler_XXX` (where `XXX` is either `DMD`, `LDC` or `GDC`).

This allows the `rdmd` bundled with DMD to be built with LDC while still defaulting to DMD.

CC @Geod24  @rikkimax