### PR TITLE
Update DustMite

### DIFF
--- a/DustMite/polyhash.d
+++ b/DustMite/polyhash.d
@@ -290,8 +290,8 @@ if (is(T : long) && T.sizeof >= 2)
 				asm
 				{
 					"`~x86SignedOpPrefix!T~`mul`~x86SizeOpSuffix!T~` %3"
-					: "=a" low, "=d" high
-					: "a" a, "rm" b;
+					: "=a"(low), "=d"(high)
+					: "a"(a), "rm"(b);
 				}
 			`);
 			return typeof(return)(low, high);
@@ -363,8 +363,8 @@ if (is(T : long) && T.sizeof >= 2 && is(L == LongInt!T))
 				asm
 				{
 					"`~x86SignedOpPrefix!T~`div`~x86SizeOpSuffix!T~` %4"
-					: "=a" quotient, "=d" remainder
-					: "a" low, "d" high, "rm" b;
+					: "=a"(quotient), "=d"(remainder)
+					: "a"(low), "d"(high), "rm"(b);
 				}
 			`);
 			return typeof(return)(quotient, remainder);


### PR DESCRIPTION
This should unblock dlang/phobos#8499 (in particular, the most recent commit).
```
* fd8c598 fuzz: Cast allAddresses length to float
* b8703eb polyhash: Update GDC assembler syntax
* 372b4a0 dustmite: Fix stdin on MSVCRT
* f594d0a dustmite: More explicit File finalization in DiskWriter
* 67e676f dustmite: Add --temp-dir
* fd28eb1 splitter: Fix compilation on 32 bits
* faee9d3 splitter: Refactor
* 461271f dustmite: Allow omitting the mask portion of --split
* 61b41ae splitter: Don't replace \ with / on POSIX
* 1bf5b4b dustmite: Print informational messages to standard error
* e504ccc dustmite: Remove use of newer D features
* 4e38836 dustmite: Add --json
* ca93991 dustmite: Fix a placeholder variable name in --help
* bba58a4 dustmite: Add --dump-json
* 1f40c63 dustmite: Add --reject
* 6634109 splitter: Add null split mode
* cb0855d dustmite: Make detection of suspicious files non-fatal
* 990b3bc splitter: Improve parsing of successive keyword-prefixed blocks
* 0a7a937 dustmite: Improve prediction formula
* 05acf86 dustmite: Implement non-linear lookahead prediction
* 732d0f1 dustmite: Add more performance timers
* 886c6f2 dustmite: Make measure's delegate scoped
* df42f62 dustmite: Add --max-steps
* 256a651 dustmite: Speed up dumping
* a10ef7f dustmite: Fix crash with --whiteout + --trace
* fd3ad29 dustmite: Speed up dependency recalculation
* e859e86 dustmite: Grow reduction application cache dynamically
* 214d000 dustmite: Add reduction application cache
* 4cfed4c dustmite: Add debug=DETERMINISTIC_LOOKAHEAD
* e76496f splitter: Make EntityRef.address const
* 6705a94 dustmite: Update tagline
* 157b305 dustmite: Remove trailing punctuation from --help text
* de92616 dustmite: Reorder --help text
* ca18a07 dustmite: Add --remove switch
* 714ea99 dustmite: Allow --reduce-only and --no-remove rules to stack
* 5fffd18 dustmite: Split up the DustMiteNoRemove string literals
* d4303ca dustmite: Add fuzzing mode
* 5e510c8 dustmite: Introduce Reduction.Type.Swap
* d2cfa23 dustmite: Allow the test function to take an array of reductions
* c04c843 dustmite: Replace Reduction.address with an Address*
* 3a76633 dustmite: Remove Reduction.target
* 6764e8d dustmite: Add --in-place
* 9505bf6 dustmite: Fix recursion for dead nodes in recalculate
* 2630496 dustmite: Fix "reduced to empty set" message
* b5c1ec0 splitter: Fix lexing D raw string literals (r"...")
* 15d0a8f dustmite: Remove use of lazy arguments in address iteration
* 965fbc3 dustmite: Speed up strategy iteration over dead nodes
* 9f5a4f1 dustmite: Create less garbage during I/O
* 226a651 dustmite: Do not copy dead entities for editing
* c3d1215 dustmite: Traverse dead entities when editing them, too
* 53d3bf6 dustmite: Recalculate dead entities recursively too
* 72cd08c dustmite: Don't attempt to concatenate dead files
* 404c8f9 dustmite: With both --trace and --dump, save dumps during trace
* 196f5f7 dustmite: Improve dump formatting of redirects and dead entities
* 48ed0a5 dustmite: Make findEntity traverse dead nodes
* d5523e1 splitter: Clear hash for killed entities
* 26f2039 dustmite: Tweak tree initialization order
* 80b7ba4 dustmite: Speed up removing dependencies under removed nodes
* 19f0200 polyhash: Add mod-q (with non-power-of-two q) support
* b1b76cd polyhash: Convert to an output range interface
* f675253 polyhash: Use decreasing powers of p, instead of increasing
* 751ea2b polyhash: Optimize calculating powers of p
* 3d28c6e polyhash: Add some comments
* 5034c01 polyhash: Initial commit
* 9eb4126 dustmite: Move lookahead saving and process creation into worker thread
* a269d25 dustmite: Distinguish zero and uninitialized digests in lookahead queue
* 6878138 dustmite: Clean up test directories before writing to them
* bf407bc dustmite: Make descendant recounting incremental
* fd45d61 dustmite: Fix placement of --version in help text
* 8b5f639 dustmite: Handle inapplicable reductions in lookahead
* 0dc5e04 dustmite: Remove special handling for the first lookahead step
* 690ab07 dustmite: Update the lookahead iterator's root according to predictions
* f197986 dustmite: Get rid of the "root" global
* 6d0cd9f dustmite: Remove `reduction == initialReduction` lookahead hack
* ad4124f dustmite: Start a new iteration after a successful Concat reduction
* 2e19085 dustmite: Fix a TODO
* 0ec8fc5 dustmite: Log inapplicable reductions
* d439fed dustmite: Remove the concatPerformed bodge
* d9da7cf dustmite: Fail no-op concat reductions
* 02f8b2e splitter: Mark Entity class final
* 3fea926 dustmite: Mark final classes as such
* 1f1f732 splitter: Don't dereference enum AAs at runtime
* 70d5503 splitter: Delete unused label
* be2c452 splitter: Fix Dscanner warning
* f56f6a4 splitter: Make Entity members used only by splitter private
* dbd493a splitter: Don't compile in a debug-only field
* 621991b dustmite: Bulk adjacent writes
* 772a8fb dustmite: Use lockingBinaryWriter
* 4d361cb dustmite: Use templates instead of delegates for dump
* e0138ca dustmite: Preserve no-remove flags when applying "Concat" reductions
* e77126f splitter: Speed up optimization
```