### PR TITLE
Remove references to the archived druntime repository

### DIFF
--- a/changed.d
+++ b/changed.d
@@ -139,7 +139,7 @@ auto getIssues(string revRange)
     enum closedRE = ctRegex!(`(?:^fix(?:es)?(?:\s+(?:issues?|bugs?))?\s+(#?\d+(?:[\s,\+&and]+#?\d+)*))`, "i");
 
     auto issues = appender!(int[]);
-    foreach (repo; ["dmd", "druntime", "phobos", "dlang.org", "tools", "installer"]
+    foreach (repo; ["dmd", "phobos", "dlang.org", "tools", "installer"]
              .map!(r => buildPath("..", r)))
     {
         auto cmd = ["git", "-C", repo, "fetch", "--tags", "https://github.com/dlang/" ~ repo.baseName,
@@ -433,7 +433,6 @@ Please supply a bugzilla version
     // location of the changelog files
     alias Repo = Tuple!(string, "name", string, "headline", string, "path");
     auto repos = [Repo("dmd", "Compiler changes", null),
-                  Repo("druntime", "Runtime changes", null),
                   Repo("phobos", "Library changes", null),
                   Repo("dlang.org", "Language changes", null),
                   Repo("installer", "Installer changes", null),

--- a/changed.d
+++ b/changed.d
@@ -276,14 +276,16 @@ Params:
 
 Returns: An InputRange of `ChangelogEntry`s
 */
-auto readTextChanges(string changelogDir, string repoName)
+auto readTextChanges(string changelogDir, string repoName, string prefix)
 {
     import std.algorithm.iteration : filter, map;
     import std.file : dirEntries, SpanMode;
+    import std.path : baseName;
     import std.string : endsWith;
 
     return dirEntries(changelogDir, SpanMode.shallow)
             .filter!(a => a.name().endsWith(".dd"))
+            .filter!(a => prefix is null || a.name().baseName.startsWith(prefix))
             .array.sort()
             .map!(a => readChangelog(a, repoName))
             .filter!(a => a.title.length > 0);
@@ -431,16 +433,17 @@ Please supply a bugzilla version
     }
 
     // location of the changelog files
-    alias Repo = Tuple!(string, "name", string, "headline", string, "path");
-    auto repos = [Repo("dmd", "Compiler changes", null),
-                  Repo("phobos", "Library changes", null),
-                  Repo("dlang.org", "Language changes", null),
-                  Repo("installer", "Installer changes", null),
-                  Repo("tools", "Tools changes", null),
-                  Repo("dub", "Dub changes", null)];
+    alias Repo = Tuple!(string, "name", string, "headline", string, "path", string, "prefix");
+    auto repos = [Repo("dmd", "Compiler changes", "changelog", "dmd."),
+                  Repo("dmd", "Runtime changes", "changelog", "druntime."),
+                  Repo("phobos", "Library changes", "changelog", null),
+                  Repo("dlang.org", "Language changes", "language-changelog", null),
+                  Repo("installer", "Installer changes", "changelog", null),
+                  Repo("tools", "Tools changes", "changelog", null),
+                  Repo("dub", "Dub changes", "changelog", null)];
 
     auto changedRepos = repos
-         .map!(repo => Repo(repo.name, repo.headline, buildPath(__FILE_FULL_PATH__.dirName, "..", repo.name, repo.name == "dlang.org" ? "language-changelog" : "changelog")))
+         .map!(repo => Repo(repo.name, repo.headline, buildPath(__FILE_FULL_PATH__.dirName, "..", repo.name, repo.path), repo.prefix))
          .filter!(r => r.path.exists);
 
     // ensure that all files either end on .dd or .md
@@ -496,7 +499,7 @@ Please supply a bugzilla version
         {
             // search for raw change files
             auto changelogDirs = changedRepos
-                 .map!(r => tuple!("headline", "changes")(r.headline, r.path.readTextChanges(r.name).array))
+                 .map!(r => tuple!("headline", "changes")(r.headline, r.path.readTextChanges(r.name, r.prefix).array))
                  .filter!(r => !r.changes.empty);
 
             // accumulate stats

--- a/contributors.d
+++ b/contributors.d
@@ -57,7 +57,7 @@ auto findAuthors(string revRange, FindConfig config)
 {
     Appender!(GitAuthor[]) authors;
     int commits;
-    auto repos = ["dmd", "druntime", "phobos", "dlang.org", "tools", "installer"];
+    auto repos = ["dmd", "phobos", "dlang.org", "tools", "installer"];
     if (config.showAllContributors)
         repos ~= ["dub", "dub-registry", "dconf.org"];
 

--- a/posix.mak
+++ b/posix.mak
@@ -3,7 +3,7 @@ BUILD = release
 DMD = $(DMD_DIR)/generated/$(OS)/$(BUILD)/$(MODEL)/dmd
 CC = gcc
 INSTALL_DIR = ../install
-DRUNTIME_PATH = ../druntime
+DRUNTIME_PATH = ../dmd/druntime
 PHOBOS_PATH = ../phobos
 DUB=dub
 

--- a/setup.sh
+++ b/setup.sh
@@ -6,10 +6,9 @@
 # First run, create a working directory, e.g. /path/to/d/. Then run
 # this script from that directory (the location of the script itself
 # doesn't matter). It will create the following subdirectories:
-# /path/to/d/dmd, /path/to/d/druntime, /path/to/d/phobos,
-# /path/to/d/dlang.org, /path/to/d/tools, and
-# /path/to/d/installer. Then it will fetch all corresponding projects
-# from github and build them fresh.
+# /path/to/d/dmd, /path/to/d/phobos, /path/to/d/dlang.org,
+# /path/to/d/tools, and /path/to/d/installer. Then it will fetch all
+# corresponding projects from github and build them fresh.
 #
 # On an ongoing basis, to update your toolchain from github go again
 # to the same directory (in our example /path/to/d) and run the script
@@ -20,7 +19,7 @@
 set -ueo pipefail
 
 declare -a projects
-projects=(dmd druntime phobos dlang.org tools installer dub)
+projects=(dmd phobos dlang.org tools installer dub)
 # Working directory
 wd=$(pwd)
 # github username
@@ -47,7 +46,7 @@ trap cleanup EXIT
 
 function help() {
     echo "./setup.sh
-Clones and builds dmd, druntime, phobos, dlang.org, tools, installer and dub.
+Clones and builds dmd, phobos, dlang.org, tools, installer and dub.
 
 Additional usage
 
@@ -151,9 +150,8 @@ function installAnew() {
             exit 1
         fi
         if [ -n "${tag}" ] ; then
-            if [ "$project" == "dmd" ] || [ "$project" == "druntime" ] || \
-                [ "$project" == "phobos" ] || [ "$project" == "dlang.org" ] || \
-                [ "$project" == "tools" ] ; then
+            if [ "$project" == "dmd" ] || [ "$project" == "phobos" ] || \
+		[ "$project" == "dlang.org" ] || [ "$project" == "tools" ] ; then
 	            git -C "$wd/$project" checkout "v$tag"
             fi
         fi
@@ -194,7 +192,7 @@ function update() {
 function makeWorld() {
     local BOOTSTRAP=""
     command -v dmd >/dev/null || BOOTSTRAP="AUTO_BOOTSTRAP=1"
-    for repo in dmd druntime phobos ; do
+    for repo in dmd phobos ; do
         # Pass `AUTO_BOOTSTRAP` because of https://issues.dlang.org/show_bug.cgi?id=20727
         "$makecmd" -C "$wd/$repo" -f posix.mak clean $BOOTSTRAP
         "$makecmd" -C "$wd/$repo" -f posix.mak "-j${parallel}" MODEL="$model" BUILD="$build" $BOOTSTRAP


### PR DESCRIPTION
It is now part of the dmd project.

In this scheme, all runtime changes will be bundled in with compiler ones, detected only by the changelog entry having an appropriate prefix.

Needed to generate the website changelogs for release.