### PR TITLE
Include dustmite as a dub subpackage

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -72,3 +72,9 @@ subPackage {
   targetType "executable"
   sourceFiles "catdoc.d"
 }
+
+subPackage {
+  name "dustmite"
+  targetType "executable"
+  sourcePaths "DustMite"
+}


### PR DESCRIPTION
This change adds a new subpackage `dtools:dustmite`. This makes building and packaging `dustmite` from here easier, as one can build it the same way they would other executables in this repository.

I did notice that a `dustmite` package is available via https://github.com/CyberShadow/DustMite/blob/master/dub.sdl, but the development there appears to be unversioned (releases/tags are cut from here), so I think there is still value in having the subpackage added here.