### PR TITLE
Dustmite/polyhash.d: Surround gcc assembly operands in parentheses

### DIFF
--- a/DustMite/polyhash.d
+++ b/DustMite/polyhash.d
@@ -290,8 +290,8 @@ if (is(T : long) && T.sizeof >= 2)
 				asm
 				{
 					"`~x86SignedOpPrefix!T~`mul`~x86SizeOpSuffix!T~` %3"
-					: "=a" low, "=d" high
-					: "a" a, "rm" b;
+					: "=a" (low), "=d" (high)
+					: "a" (a), "rm" (b);
 				}
 			`);
 			return typeof(return)(low, high);
@@ -363,8 +363,8 @@ if (is(T : long) && T.sizeof >= 2 && is(L == LongInt!T))
 				asm
 				{
 					"`~x86SignedOpPrefix!T~`div`~x86SizeOpSuffix!T~` %4"
-					: "=a" quotient, "=d" remainder
-					: "a" low, "d" high, "rm" b;
+					: "=a" (quotient), "=d" (remainder)
+					: "a" (low), "d" (high), "rm" (b);
 				}
 			`);
 			return typeof(return)(quotient, remainder);


### PR DESCRIPTION
Compiling with recent versions of gdc results in errors:
```
DustMite/polyhash.d-mixin-289:293:13: error: ‘low’ must be surrounded by parentheses
DustMite/polyhash.d-mixin-289:293:23: error: ‘high’ must be surrounded by parentheses
DustMite/polyhash.d-mixin-289:294:12: error: ‘a’ must be surrounded by parentheses
DustMite/polyhash.d-mixin-289:294:20: error: ‘b’ must be surrounded by parentheses
DustMite/polyhash.d:165:37: error: template instance ‘polyhash.longMul!ulong’ error instantiating
  165 |                 this.value = longMul(this.value, operand.value).longDiv(q).remainder;
      |                                     ^
DustMite/polyhash.d:32:35: note: instantiated from here: ‘opOpAssign!"*"’
   32 |                                 v *= v;
      |                                   ^
DustMite/splitter.d:50:28: note: instantiated from here: ‘PolynomialHash!(ModQ!(ulong, 18446744073709551557LU))’
   50 |         alias EntityHash = PolynomialHash!(ModQ!(ulong, largest64bitPrime));
      |                            ^
DustMite/polyhash.d-mixin-362:366:13: error: ‘quotient’ must be surrounded by parentheses
DustMite/polyhash.d-mixin-362:366:28: error: ‘remainder’ must be surrounded by parentheses
DustMite/polyhash.d-mixin-362:367:12: error: ‘low’ must be surrounded by parentheses
DustMite/polyhash.d-mixin-362:367:21: error: ‘high’ must be surrounded by parentheses
DustMite/polyhash.d-mixin-362:367:32: error: ‘b’ must be surrounded by parentheses
DustMite/polyhash.d:165:72: error: template instance ‘polyhash.longDiv!(ulong, LongInt!(64u, false))’ error instantiating
  165 |                this.value = longMul(this.value, operand.value).longDiv(q).remainder;
      |                                                                       ^

DustMite/polyhash.d:32:35: note: instantiated from here: ‘opOpAssign!"*"’
   32 |                                 v *= v;
      |                                   ^
DustMite/splitter.d:50:28: note: instantiated from here: ‘PolynomialHash!(ModQ!(ulong, 18446744073709551557LU))’
   50 |         alias EntityHash = PolynomialHash!(ModQ!(ulong, largest64bitPrime));
      |                            ^
```