### PR TITLE
Bump OSX runner image to 14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-13, ubuntu-latest, windows-latest ]
+        os: [ macos-14, ubuntu-latest, windows-latest ]
         dc: [ dmd-latest, ldc-latest ]
     name: ${{ matrix.os }}, ${{ matrix.dc }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
> The configuration 'macos-13-us-default' is not supported